### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The library is published as a
 [Composer](http://getcomposer.org/):
 
 ```
-$ composer require jmikola/geojson=1.0.*@dev
+$ composer require "jmikola/geojson=1.0.*@dev"
 ```
 
 ## Usage


### PR DESCRIPTION
The AT sign is a special characters in many shells, added quotes to prevent errors such as `zsh: no matches found: jmikola/geojson=1.0.*@dev`
