### PR TITLE
Fix php warning on LinearRing creation with invalid params

### DIFF
--- a/src/GeoJson/Geometry/Polygon.php
+++ b/src/GeoJson/Geometry/Polygon.php
@@ -22,16 +22,12 @@ class Polygon extends Geometry
      */
     public function __construct(array $linearRings)
     {
-        $this->coordinates = array_map(
-            function($linearRing) {
-                if ( ! $linearRing instanceof LinearRing) {
-                    $linearRing = new LinearRing($linearRing);
-                }
-
-                return $linearRing->getCoordinates();
-            },
-            $linearRings
-        );
+        foreach ($linearRings as $linearRing) {
+            if ( ! $linearRing instanceof LinearRing) {
+                $linearRing = new LinearRing($linearRing);
+            }
+            $this->coordinates[] = $linearRing->getCoordinates();
+        }
 
         if (func_num_args() > 1) {
             $this->setOptionalConstructorArgs(array_slice(func_get_args(), 1));


### PR DESCRIPTION
Fixes issue #18

When not correct data is used to create Polygon following php warning is shown
```php
new \GeoJson\Geometry\Polygon([[2,4]]);

PHP Warning:  array_map(): An error occurred while invoking the map callback in ...
```