### PR TITLE
Apply language level migrations and clean-ups

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+*.php diff=php
+
+/tests export-ignore
+
+/.gitattributes export-ignore
+/.github export-ignore
+/.gitignore export-ignore
+/.scrutinizer.yml export-ignore
+/phpcs.xml.dist export-ignore
+/phpunit.xml.dist export-ignore

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -1,0 +1,46 @@
+name: "Coding Standards"
+
+on:
+  pull_request:
+    branches:
+      - "v*.*"
+      - "master"
+  push:
+    branches:
+      - "v*.*"
+      - "master"
+
+jobs:
+  coding-standards:
+    name: "Coding Standards"
+    runs-on: "ubuntu-20.04"
+
+    strategy:
+      matrix:
+        php-version:
+          - "7.4"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
+          tools: "cs2pr"
+
+      - name: "Cache dependencies installed with Composer"
+        uses: "actions/cache@v2"
+        with:
+          path: "~/.composer/cache"
+          key: "php-${{ matrix.php-version }}-composer-locked-${{ hashFiles('composer.lock') }}"
+          restore-keys: "php-${{ matrix.php-version }}-composer-locked-"
+
+      - name: "Install dependencies with Composer"
+        run: "composer install --no-interaction --no-progress --no-suggest"
+
+      # The -q option is required until phpcs v4 is released
+      - name: "Run PHP_CodeSniffer"
+        run: "vendor/bin/phpcs -q --no-colors --report=checkstyle | cs2pr"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .phpunit.result.cache
 composer.lock
 phpunit.xml
-site
 vendor

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.phpcs-cache
 .phpunit.result.cache
 composer.lock
 phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "ext-json": "*"
+        "ext-json": "*",
+        "symfony/polyfill-php80": "^1.25"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,9 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "scrutinizer/ocular": "^1.8.1"
+        "scrutinizer/ocular": "^1.8.1",
+        "squizlabs/php_codesniffer": "^3.6",
+        "slevomat/coding-standard": "^7.0"
     },
     "autoload": {
         "psr-0": { "GeoJson\\": "src/" }
@@ -22,6 +24,11 @@
     "extra": {
         "branch-alias": {
             "dev-master": "1.1-dev"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,168 @@
+<?xml version="1.0"?>
+<ruleset>
+    <arg name="basepath" value="." />
+    <arg name="extensions" value="php" />
+    <arg name="cache" value=".phpcs-cache" />
+    <arg name="colors" />
+
+    <!-- Ignore warnings (n), show progress of the run (p), and show sniff names (s) -->
+    <arg value="nps"/>
+
+    <file>src</file>
+    <file>tests</file>
+
+    <rule ref="PSR12">
+
+        <!-- ********************************************** -->
+        <!-- Exclude sniffs that require newer PHP versions -->
+        <!-- ********************************************** -->
+
+        <!-- Requires PHP 8.0 -->
+        <exclude name="SlevomatCodingStandard.Classes.ModernClassNameReference.ClassNameReferencedViaFunctionCall" />
+
+
+        <!-- *********************************** -->
+        <!-- Exclude sniffs that cause BC breaks -->
+        <!-- *********************************** -->
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming" />
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming" />
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming" />
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousTraitNaming" />
+
+
+        <!-- **************************************** -->
+        <!-- Exclude sniffs that force unwanted style -->
+        <!-- **************************************** -->
+        <exclude name="Generic.Formatting.MultipleStatementAlignment" />
+        <exclude name="Squiz.Commenting.FunctionComment.ThrowsNoFullStop" />
+
+        <!-- Keep long typehints (for now) -->
+        <exclude name="SlevomatCodingStandard.PHP.TypeCast.InvalidCastUsed" />
+        <exclude name="SlevomatCodingStandard.TypeHints.LongTypeHints" />
+
+
+        <!-- ************************************************ -->
+        <!-- Exclude sniffs that may cause functional changes -->
+        <!-- ************************************************ -->
+        <exclude name="Generic.PHP.ForbiddenFunctions.FoundWithAlternative" />
+        <exclude name="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison" />
+        <exclude name="SlevomatCodingStandard.ControlStructures.EarlyExit" />
+        <exclude name="SlevomatCodingStandard.ControlStructures.UselessIfConditionWithReturn" />
+        <exclude name="SlevomatCodingStandard.Functions.StaticClosure" />
+        <exclude name="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure" />
+        <exclude name="SlevomatCodingStandard.Operators.DisallowEqualOperators" />
+
+
+        <!-- ********************************************************* -->
+        <!-- Exclude sniffs that cause a huge diff - enable separately -->
+        <!-- ********************************************************* -->
+        <exclude name="SlevomatCodingStandard.Commenting.DocCommentSpacing.IncorrectAnnotationsGroup" />
+        <exclude name="Squiz.Strings.DoubleQuoteUsage" />
+
+
+        <!-- ********************* -->
+        <!-- Exclude broken sniffs -->
+        <!-- ********************* -->
+
+        <!-- Sniff currently broken when casting arrays, see https://github.com/squizlabs/PHP_CodeSniffer/issues/2937#issuecomment-615498860 -->
+        <exclude name="Squiz.Arrays.ArrayDeclaration.ValueNoNewline" />
+
+        <!-- Disable forbidden annotation sniff as excluding @api from the list doesn't work -->
+        <exclude name="SlevomatCodingStandard.Commenting.ForbiddenAnnotations.AnnotationForbidden" />
+    </rule>
+
+
+    <!-- ***************************************************** -->
+    <!-- Forbid fully qualified names even for colliding names -->
+    <!-- ***************************************************** -->
+    <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
+        <properties>
+            <property name="allowFallbackGlobalConstants" value="false"/>
+            <property name="allowFallbackGlobalFunctions" value="false"/>
+            <property name="allowFullyQualifiedGlobalClasses" value="false"/>
+            <property name="allowFullyQualifiedGlobalConstants" value="false"/>
+            <property name="allowFullyQualifiedGlobalFunctions" value="false"/>
+            <property phpcs-only="true" name="allowFullyQualifiedNameForCollidingClasses" value="false"/>
+            <property phpcs-only="true" name="allowFullyQualifiedNameForCollidingConstants" value="false"/>
+            <property phpcs-only="true" name="allowFullyQualifiedNameForCollidingFunctions" value="false"/>
+            <property name="searchAnnotations" value="true"/>
+        </properties>
+    </rule>
+
+    <!-- **************************************************************************** -->
+    <!-- Exclude BC breaking type hints for parameters, properties, and return values -->
+    <!-- **************************************************************************** -->
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
+        <properties>
+            <!-- Requires PHP 8.0 -->
+            <property name="enableMixedTypeHint" value="false" />
+            <!-- Requires PHP 8.0 -->
+            <property name="enableUnionTypeHint" value="false" />
+        </properties>
+
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification" />
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.UselessAnnotation" />
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
+        <properties>
+            <!-- Requires PHP 8.0 -->
+            <property name="enableMixedTypeHint" value="false" />
+            <!-- Requires PHP 8.0 -->
+            <property name="enableUnionTypeHint" value="false" />
+        </properties>
+
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification" />
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.UselessAnnotation" />
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
+        <properties>
+            <!-- Requires PHP 8.0 -->
+            <property name="enableStaticTypeHint" value="false" />
+            <!-- Requires PHP 8.0 -->
+            <property name="enableMixedTypeHint" value="false" />
+            <!-- Requires PHP 8.0 -->
+            <property name="enableUnionTypeHint" value="false" />
+        </properties>
+
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification" />
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessAnnotation" />
+    </rule>
+
+
+    <!-- ************************************************************************** -->
+    <!-- Require type hints for all parameters, properties, and return types in src -->
+    <!-- ************************************************************************** -->
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint">
+        <exclude-pattern>tests</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint">
+        <exclude-pattern>tests</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingAnyTypeHint">
+        <exclude-pattern>tests</exclude-pattern>
+    </rule>
+
+
+    <!-- *********************************************************************************** -->
+    <!-- Require native type hints for all parameters, properties, and return types in tests -->
+    <!-- *********************************************************************************** -->
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint">
+        <exclude-pattern>src</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint">
+        <exclude-pattern>src</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint">
+        <exclude-pattern>src</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
+        <properties>
+            <property name="newlinesCountBetweenOpenTagAndDeclare" type="int" value="2" />
+            <property name="spacesCountAroundEqualsSign" type="int" value="0" />
+        </properties>
+    </rule>
+
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax" />
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,7 @@
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-    bootstrap="tests/bootstrap.php"
+    colors="true"
 >
     <testsuites>
         <testsuite name="GeoJson Test Suite">

--- a/src/GeoJson/BoundingBox.php
+++ b/src/GeoJson/BoundingBox.php
@@ -1,10 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson;
 
 use GeoJson\Exception\UnserializationException;
 use InvalidArgumentException;
 use JsonSerializable;
+
+use function count;
+use function is_int;
+use function is_float;
+use function is_array;
 
 /**
  * BoundingBox object.
@@ -35,7 +42,7 @@ class BoundingBox implements JsonSerializable, JsonUnserializable
         }
 
         foreach ($bounds as $value) {
-            if ( ! is_int($value) && ! is_float($value)) {
+            if (! is_int($value) && ! is_float($value)) {
                 throw new InvalidArgumentException('BoundingBox values must be integers or floats');
             }
         }
@@ -64,9 +71,12 @@ class BoundingBox implements JsonSerializable, JsonUnserializable
         return $this->bounds;
     }
 
+    /**
+     * @param array $json
+     */
     final public static function jsonUnserialize($json): self
     {
-        if ( ! is_array($json)) {
+        if (! is_array($json)) {
             throw UnserializationException::invalidValue('BoundingBox', $json, 'array');
         }
 

--- a/src/GeoJson/BoundingBox.php
+++ b/src/GeoJson/BoundingBox.php
@@ -15,14 +15,12 @@ use JsonSerializable;
 class BoundingBox implements JsonSerializable, JsonUnserializable
 {
     /**
-     * @var array
+     * @var array<float|int>
      */
-    protected $bounds;
+    protected array $bounds;
 
     /**
-     * Constructor.
-     *
-     * @param float[] $bounds
+     * @param array<float|int> $bounds
      */
     public function __construct(array $bounds)
     {
@@ -54,9 +52,9 @@ class BoundingBox implements JsonSerializable, JsonUnserializable
     /**
      * Return the bounds for this BoundingBox object.
      *
-     * @return float[]
+     * @return array<float|int>
      */
-    public function getBounds()
+    public function getBounds(): array
     {
         return $this->bounds;
     }
@@ -66,7 +64,7 @@ class BoundingBox implements JsonSerializable, JsonUnserializable
         return $this->bounds;
     }
 
-    final public static function jsonUnserialize($json)
+    final public static function jsonUnserialize($json): self
     {
         if ( ! is_array($json)) {
             throw UnserializationException::invalidValue('BoundingBox', $json, 'array');

--- a/src/GeoJson/BoundingBox.php
+++ b/src/GeoJson/BoundingBox.php
@@ -61,17 +61,11 @@ class BoundingBox implements JsonSerializable, JsonUnserializable
         return $this->bounds;
     }
 
-    /**
-     * @see http://php.net/manual/en/jsonserializable.jsonserialize.php
-     */
     public function jsonSerialize(): array
     {
         return $this->bounds;
     }
 
-    /**
-     * @see JsonUnserializable::jsonUnserialize()
-     */
     final public static function jsonUnserialize($json)
     {
         if ( ! is_array($json)) {

--- a/src/GeoJson/BoundingBox.php
+++ b/src/GeoJson/BoundingBox.php
@@ -3,6 +3,8 @@
 namespace GeoJson;
 
 use GeoJson\Exception\UnserializationException;
+use InvalidArgumentException;
+use JsonSerializable;
 
 /**
  * BoundingBox object.
@@ -10,7 +12,7 @@ use GeoJson\Exception\UnserializationException;
  * @see http://www.geojson.org/geojson-spec.html#bounding-boxes
  * @since 1.0
  */
-class BoundingBox implements \JsonSerializable, JsonUnserializable
+class BoundingBox implements JsonSerializable, JsonUnserializable
 {
     /**
      * @var array
@@ -27,22 +29,22 @@ class BoundingBox implements \JsonSerializable, JsonUnserializable
         $count = count($bounds);
 
         if ($count < 4) {
-            throw new \InvalidArgumentException('BoundingBox requires at least four values');
+            throw new InvalidArgumentException('BoundingBox requires at least four values');
         }
 
         if ($count % 2) {
-            throw new \InvalidArgumentException('BoundingBox requires an even number of values');
+            throw new InvalidArgumentException('BoundingBox requires an even number of values');
         }
 
         foreach ($bounds as $value) {
             if ( ! is_int($value) && ! is_float($value)) {
-                throw new \InvalidArgumentException('BoundingBox values must be integers or floats');
+                throw new InvalidArgumentException('BoundingBox values must be integers or floats');
             }
         }
 
         for ($i = 0; $i < ($count / 2); $i++) {
             if ($bounds[$i] > $bounds[$i + ($count / 2)]) {
-                throw new \InvalidArgumentException('BoundingBox min values must precede max values');
+                throw new InvalidArgumentException('BoundingBox min values must precede max values');
             }
         }
 

--- a/src/GeoJson/CoordinateReferenceSystem/CoordinateReferenceSystem.php
+++ b/src/GeoJson/CoordinateReferenceSystem/CoordinateReferenceSystem.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\CoordinateReferenceSystem;
 
 use ArrayObject;
@@ -7,6 +9,10 @@ use BadMethodCallException;
 use GeoJson\Exception\UnserializationException;
 use GeoJson\JsonUnserializable;
 use JsonSerializable;
+
+use function is_array;
+use function is_object;
+use function sprintf;
 
 /**
  * Coordinate reference system object.
@@ -38,25 +44,28 @@ abstract class CoordinateReferenceSystem implements JsonSerializable, JsonUnseri
 
     public function jsonSerialize(): array
     {
-        return array(
+        return [
             'type' => $this->type,
             'properties' => $this->properties,
-        );
+        ];
     }
 
-    final public static function jsonUnserialize($json)
+    /**
+     * @param array|object $json
+     */
+    final public static function jsonUnserialize($json): self
     {
-        if ( ! is_array($json) && ! is_object($json)) {
+        if (! is_array($json) && ! is_object($json)) {
             throw UnserializationException::invalidValue('CRS', $json, 'array or object');
         }
 
         $json = new ArrayObject($json);
 
-        if ( ! $json->offsetExists('type')) {
+        if (! $json->offsetExists('type')) {
             throw UnserializationException::missingProperty('CRS', 'type', 'string');
         }
 
-        if ( ! $json->offsetExists('properties')) {
+        if (! $json->offsetExists('properties')) {
             throw UnserializationException::missingProperty('CRS', 'properties', 'array or object');
         }
 

--- a/src/GeoJson/CoordinateReferenceSystem/CoordinateReferenceSystem.php
+++ b/src/GeoJson/CoordinateReferenceSystem/CoordinateReferenceSystem.php
@@ -46,9 +46,6 @@ abstract class CoordinateReferenceSystem implements JsonSerializable, JsonUnseri
         return $this->type;
     }
 
-    /**
-     * @see http://php.net/manual/en/jsonserializable.jsonserialize.php
-     */
     public function jsonSerialize(): array
     {
         return array(
@@ -57,9 +54,6 @@ abstract class CoordinateReferenceSystem implements JsonSerializable, JsonUnseri
         );
     }
 
-    /**
-     * @see JsonUnserializable::jsonUnserialize()
-     */
     final public static function jsonUnserialize($json)
     {
         if ( ! is_array($json) && ! is_object($json)) {
@@ -95,7 +89,6 @@ abstract class CoordinateReferenceSystem implements JsonSerializable, JsonUnseri
      *
      * This method must be overridden in a child class.
      *
-     * @see CoordinateReferenceSystem::jsonUnserialize()
      * @param array|object $properties
      * @return CoordinateReferenceSystem
      * @throws BadMethodCallException

--- a/src/GeoJson/CoordinateReferenceSystem/CoordinateReferenceSystem.php
+++ b/src/GeoJson/CoordinateReferenceSystem/CoordinateReferenceSystem.php
@@ -2,8 +2,11 @@
 
 namespace GeoJson\CoordinateReferenceSystem;
 
+use ArrayObject;
+use BadMethodCallException;
 use GeoJson\Exception\UnserializationException;
 use GeoJson\JsonUnserializable;
+use JsonSerializable;
 
 /**
  * Coordinate reference system object.
@@ -11,7 +14,7 @@ use GeoJson\JsonUnserializable;
  * @see http://www.geojson.org/geojson-spec.html#coordinate-reference-system-objects
  * @since 1.0
  */
-abstract class CoordinateReferenceSystem implements \JsonSerializable, JsonUnserializable
+abstract class CoordinateReferenceSystem implements JsonSerializable, JsonUnserializable
 {
     /**
      * @var array
@@ -63,7 +66,7 @@ abstract class CoordinateReferenceSystem implements \JsonSerializable, JsonUnser
             throw UnserializationException::invalidValue('CRS', $json, 'array or object');
         }
 
-        $json = new \ArrayObject($json);
+        $json = new ArrayObject($json);
 
         if ( ! $json->offsetExists('type')) {
             throw UnserializationException::missingProperty('CRS', 'type', 'string');
@@ -95,10 +98,10 @@ abstract class CoordinateReferenceSystem implements \JsonSerializable, JsonUnser
      * @see CoordinateReferenceSystem::jsonUnserialize()
      * @param array|object $properties
      * @return CoordinateReferenceSystem
-     * @throws \BadMethodCallException
+     * @throws BadMethodCallException
      */
     protected static function jsonUnserializeFromProperties($properties)
     {
-        throw new \BadMethodCallException(sprintf('%s must be overridden in a child class', __METHOD__));
+        throw new BadMethodCallException(sprintf('%s must be overridden in a child class', __METHOD__));
     }
 }

--- a/src/GeoJson/CoordinateReferenceSystem/CoordinateReferenceSystem.php
+++ b/src/GeoJson/CoordinateReferenceSystem/CoordinateReferenceSystem.php
@@ -16,32 +16,22 @@ use JsonSerializable;
  */
 abstract class CoordinateReferenceSystem implements JsonSerializable, JsonUnserializable
 {
-    /**
-     * @var array
-     */
-    protected $properties;
+    protected array $properties;
 
-    /**
-     * @var string
-     */
-    protected $type;
+    protected string $type;
 
     /**
      * Return the properties for this CRS object.
-     *
-     * @return array
      */
-    public function getProperties()
+    public function getProperties(): array
     {
         return $this->properties;
     }
 
     /**
      * Return the type for this CRS object.
-     *
-     * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }
@@ -90,10 +80,10 @@ abstract class CoordinateReferenceSystem implements JsonSerializable, JsonUnseri
      * This method must be overridden in a child class.
      *
      * @param array|object $properties
-     * @return CoordinateReferenceSystem
+     *
      * @throws BadMethodCallException
      */
-    protected static function jsonUnserializeFromProperties($properties)
+    protected static function jsonUnserializeFromProperties($properties): CoordinateReferenceSystem
     {
         throw new BadMethodCallException(sprintf('%s must be overridden in a child class', __METHOD__));
     }

--- a/src/GeoJson/CoordinateReferenceSystem/CoordinateReferenceSystem.php
+++ b/src/GeoJson/CoordinateReferenceSystem/CoordinateReferenceSystem.php
@@ -17,6 +17,10 @@ use function sprintf;
 /**
  * Coordinate reference system object.
  *
+ * @deprecated 1.1 Specification of coordinate reference systems has been removed, i.e.,
+ *                 the 'crs' member of [GJ2008] is no longer used.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc7946#appendix-B.1
  * @see http://www.geojson.org/geojson-spec.html#coordinate-reference-system-objects
  * @since 1.0
  */

--- a/src/GeoJson/CoordinateReferenceSystem/Linked.php
+++ b/src/GeoJson/CoordinateReferenceSystem/Linked.php
@@ -1,9 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\CoordinateReferenceSystem;
 
 use ArrayObject;
 use GeoJson\Exception\UnserializationException;
+
+use function is_array;
+use function is_object;
 
 /**
  * Linked coordinate reference system object.
@@ -17,7 +22,7 @@ class Linked extends CoordinateReferenceSystem
 
     public function __construct(string $href, ?string $type = null)
     {
-        $this->properties = array('href' => $href);
+        $this->properties = ['href' => $href];
 
         if ($type !== null) {
             $this->properties['type'] = $type;
@@ -31,15 +36,15 @@ class Linked extends CoordinateReferenceSystem
      *
      * @throws UnserializationException
      */
-    protected static function jsonUnserializeFromProperties($properties): Linked
+    protected static function jsonUnserializeFromProperties($properties): self
     {
-        if ( ! is_array($properties) && ! is_object($properties)) {
+        if (! is_array($properties) && ! is_object($properties)) {
             throw UnserializationException::invalidProperty('Linked CRS', 'properties', $properties, 'array or object');
         }
 
         $properties = new ArrayObject($properties);
 
-        if ( ! $properties->offsetExists('href')) {
+        if (! $properties->offsetExists('href')) {
             throw UnserializationException::missingProperty('Linked CRS', 'properties.href', 'string');
         }
 

--- a/src/GeoJson/CoordinateReferenceSystem/Linked.php
+++ b/src/GeoJson/CoordinateReferenceSystem/Linked.php
@@ -2,6 +2,7 @@
 
 namespace GeoJson\CoordinateReferenceSystem;
 
+use ArrayObject;
 use GeoJson\Exception\UnserializationException;
 
 /**
@@ -43,7 +44,7 @@ class Linked extends CoordinateReferenceSystem
             throw UnserializationException::invalidProperty('Linked CRS', 'properties', $properties, 'array or object');
         }
 
-        $properties = new \ArrayObject($properties);
+        $properties = new ArrayObject($properties);
 
         if ( ! $properties->offsetExists('href')) {
             throw UnserializationException::missingProperty('Linked CRS', 'properties.href', 'string');

--- a/src/GeoJson/CoordinateReferenceSystem/Linked.php
+++ b/src/GeoJson/CoordinateReferenceSystem/Linked.php
@@ -13,20 +13,14 @@ use GeoJson\Exception\UnserializationException;
  */
 class Linked extends CoordinateReferenceSystem
 {
-    protected $type = 'link';
+    protected string $type = 'link';
 
-    /**
-     * Constructor.
-     *
-     * @param string $href
-     * @param string $type
-     */
-    public function __construct($href, $type = null)
+    public function __construct(string $href, ?string $type = null)
     {
-        $this->properties = array('href' => (string) $href);
+        $this->properties = array('href' => $href);
 
-        if (isset($type)) {
-            $this->properties['type'] = (string) $type;
+        if ($type !== null) {
+            $this->properties['type'] = $type;
         }
     }
 
@@ -34,10 +28,10 @@ class Linked extends CoordinateReferenceSystem
      * Factory method for creating a Linked CRS object from properties.
      *
      * @param array|object $properties
-     * @return Linked
+     *
      * @throws UnserializationException
      */
-    protected static function jsonUnserializeFromProperties($properties)
+    protected static function jsonUnserializeFromProperties($properties): Linked
     {
         if ( ! is_array($properties) && ! is_object($properties)) {
             throw UnserializationException::invalidProperty('Linked CRS', 'properties', $properties, 'array or object');

--- a/src/GeoJson/CoordinateReferenceSystem/Linked.php
+++ b/src/GeoJson/CoordinateReferenceSystem/Linked.php
@@ -33,7 +33,6 @@ class Linked extends CoordinateReferenceSystem
     /**
      * Factory method for creating a Linked CRS object from properties.
      *
-     * @see CoordinateReferenceSystem::jsonUnserialize()
      * @param array|object $properties
      * @return Linked
      * @throws UnserializationException

--- a/src/GeoJson/CoordinateReferenceSystem/Linked.php
+++ b/src/GeoJson/CoordinateReferenceSystem/Linked.php
@@ -13,6 +13,10 @@ use function is_object;
 /**
  * Linked coordinate reference system object.
  *
+ * @deprecated 1.1 Specification of coordinate reference systems has been removed, i.e.,
+ *                 the 'crs' member of [GJ2008] is no longer used.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc7946#appendix-B.1
  * @see http://www.geojson.org/geojson-spec.html#linked-crs
  * @since 1.0
  */

--- a/src/GeoJson/CoordinateReferenceSystem/Named.php
+++ b/src/GeoJson/CoordinateReferenceSystem/Named.php
@@ -2,6 +2,7 @@
 
 namespace GeoJson\CoordinateReferenceSystem;
 
+use ArrayObject;
 use GeoJson\Exception\UnserializationException;
 
 /**
@@ -38,7 +39,7 @@ class Named extends CoordinateReferenceSystem
             throw UnserializationException::invalidProperty('Named CRS', 'properties', $properties, 'array or object');
         }
 
-        $properties = new \ArrayObject($properties);
+        $properties = new ArrayObject($properties);
 
         if ( ! $properties->offsetExists('name')) {
             throw UnserializationException::missingProperty('Named CRS', 'properties.name', 'string');

--- a/src/GeoJson/CoordinateReferenceSystem/Named.php
+++ b/src/GeoJson/CoordinateReferenceSystem/Named.php
@@ -1,9 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\CoordinateReferenceSystem;
 
 use ArrayObject;
 use GeoJson\Exception\UnserializationException;
+
+use function is_array;
+use function is_object;
 
 /**
  * Named coordinate reference system object.
@@ -17,7 +22,7 @@ class Named extends CoordinateReferenceSystem
 
     public function __construct(string $name)
     {
-        $this->properties = array('name' => $name);
+        $this->properties = ['name' => $name];
     }
 
     /**
@@ -27,15 +32,15 @@ class Named extends CoordinateReferenceSystem
      *
      * @throws UnserializationException
      */
-    protected static function jsonUnserializeFromProperties($properties): Named
+    protected static function jsonUnserializeFromProperties($properties): self
     {
-        if ( ! is_array($properties) && ! is_object($properties)) {
+        if (! is_array($properties) && ! is_object($properties)) {
             throw UnserializationException::invalidProperty('Named CRS', 'properties', $properties, 'array or object');
         }
 
         $properties = new ArrayObject($properties);
 
-        if ( ! $properties->offsetExists('name')) {
+        if (! $properties->offsetExists('name')) {
             throw UnserializationException::missingProperty('Named CRS', 'properties.name', 'string');
         }
 

--- a/src/GeoJson/CoordinateReferenceSystem/Named.php
+++ b/src/GeoJson/CoordinateReferenceSystem/Named.php
@@ -28,7 +28,6 @@ class Named extends CoordinateReferenceSystem
     /**
      * Factory method for creating a Named CRS object from properties.
      *
-     * @see CoordinateReferenceSystem::jsonUnserialize()
      * @param array|object $properties
      * @return Named
      * @throws UnserializationException

--- a/src/GeoJson/CoordinateReferenceSystem/Named.php
+++ b/src/GeoJson/CoordinateReferenceSystem/Named.php
@@ -13,26 +13,21 @@ use GeoJson\Exception\UnserializationException;
  */
 class Named extends CoordinateReferenceSystem
 {
-    protected $type = 'name';
+    protected string $type = 'name';
 
-    /**
-     * Constructor.
-     *
-     * @param string $name
-     */
-    public function __construct($name)
+    public function __construct(string $name)
     {
-        $this->properties = array('name' => (string) $name);
+        $this->properties = array('name' => $name);
     }
 
     /**
      * Factory method for creating a Named CRS object from properties.
      *
      * @param array|object $properties
-     * @return Named
+     *
      * @throws UnserializationException
      */
-    protected static function jsonUnserializeFromProperties($properties)
+    protected static function jsonUnserializeFromProperties($properties): Named
     {
         if ( ! is_array($properties) && ! is_object($properties)) {
             throw UnserializationException::invalidProperty('Named CRS', 'properties', $properties, 'array or object');

--- a/src/GeoJson/CoordinateReferenceSystem/Named.php
+++ b/src/GeoJson/CoordinateReferenceSystem/Named.php
@@ -13,6 +13,9 @@ use function is_object;
 /**
  * Named coordinate reference system object.
  *
+ * @deprecated 1.1 Specification of coordinate reference systems has been removed, i.e.,
+ *                 the 'crs' member of [GJ2008] is no longer used.
+ *
  * @see http://www.geojson.org/geojson-spec.html#named-crs
  * @since 1.0
  */

--- a/src/GeoJson/Exception/Exception.php
+++ b/src/GeoJson/Exception/Exception.php
@@ -1,5 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Exception;
 
-interface Exception {}
+interface Exception
+{
+}

--- a/src/GeoJson/Exception/UnserializationException.php
+++ b/src/GeoJson/Exception/UnserializationException.php
@@ -1,8 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Exception;
 
 use RuntimeException;
+
+use function sprintf;
+use function is_object;
+use function get_class;
+use function gettype;
 
 class UnserializationException extends RuntimeException implements Exception
 {

--- a/src/GeoJson/Exception/UnserializationException.php
+++ b/src/GeoJson/Exception/UnserializationException.php
@@ -9,12 +9,9 @@ class UnserializationException extends RuntimeException implements Exception
     /**
      * Creates an UnserializationException for a value with an invalid type.
      *
-     * @param string $context
      * @param mixed $value
-     * @param string $expectedType
-     * @return UnserializationException
      */
-    public static function invalidValue($context, $value, $expectedType)
+    public static function invalidValue(string $context, $value, string $expectedType): self
     {
         return new self(sprintf(
             '%s expected value of type %s, %s given',
@@ -27,13 +24,9 @@ class UnserializationException extends RuntimeException implements Exception
     /**
      * Creates an UnserializationException for a property with an invalid type.
      *
-     * @param string $context
-     * @param string $property
      * @param mixed $value
-     * @param string $expectedType
-     * @return UnserializationException
      */
-    public static function invalidProperty($context, $property, $value, $expectedType)
+    public static function invalidProperty(string $context, string $property, $value, string $expectedType): self
     {
         return new self(sprintf(
             '%s expected "%s" property of type %s, %s given',
@@ -46,13 +39,8 @@ class UnserializationException extends RuntimeException implements Exception
 
     /**
      * Creates an UnserializationException for a missing property.
-     *
-     * @param string $context
-     * @param string $property
-     * @param string $expectedType
-     * @return UnserializationException
      */
-    public static function missingProperty($context, $property, $expectedType)
+    public static function missingProperty(string $context, string $property, string $expectedType): self
     {
         return new self(sprintf(
             '%s expected "%s" property of type %s, none given',
@@ -64,12 +52,8 @@ class UnserializationException extends RuntimeException implements Exception
 
     /**
      * Creates an UnserializationException for an unsupported "type" property.
-     *
-     * @param string $context
-     * @param string $value
-     * @return UnserializationException
      */
-    public static function unsupportedType($context, $value)
+    public static function unsupportedType(string $context, string $value): self
     {
         return new self(sprintf('Invalid %s type "%s"', $context, $value));
     }

--- a/src/GeoJson/Exception/UnserializationException.php
+++ b/src/GeoJson/Exception/UnserializationException.php
@@ -2,7 +2,9 @@
 
 namespace GeoJson\Exception;
 
-class UnserializationException extends \RuntimeException implements Exception
+use RuntimeException;
+
+class UnserializationException extends RuntimeException implements Exception
 {
     /**
      * Creates an UnserializationException for a value with an invalid type.

--- a/src/GeoJson/Exception/UnserializationException.php
+++ b/src/GeoJson/Exception/UnserializationException.php
@@ -10,6 +10,7 @@ use function sprintf;
 use function is_object;
 use function get_class;
 use function gettype;
+use function get_debug_type;
 
 class UnserializationException extends RuntimeException implements Exception
 {
@@ -24,7 +25,7 @@ class UnserializationException extends RuntimeException implements Exception
             '%s expected value of type %s, %s given',
             $context,
             $expectedType,
-            is_object($value) ? get_class($value) : gettype($value)
+            get_debug_type($value)
         ));
     }
 

--- a/src/GeoJson/Feature/Feature.php
+++ b/src/GeoJson/Feature/Feature.php
@@ -4,6 +4,7 @@ namespace GeoJson\Feature;
 
 use GeoJson\GeoJson;
 use GeoJson\Geometry\Geometry;
+use stdClass;
 
 /**
  * Feature object.
@@ -95,7 +96,7 @@ class Feature extends GeoJson
 
         // Ensure empty associative arrays are encoded as JSON objects
         if ($json['properties'] === array()) {
-            $json['properties'] = new \stdClass();
+            $json['properties'] = new stdClass();
         }
 
         if (isset($this->id)) {

--- a/src/GeoJson/Feature/Feature.php
+++ b/src/GeoJson/Feature/Feature.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Feature;
 
 use GeoJson\BoundingBox;
@@ -40,7 +42,7 @@ class Feature extends GeoJson
      * @param int|string|null $id
      * @param CoordinateReferenceSystem|BoundingBox $args
      */
-    public function __construct(?Geometry $geometry = null, ?array $properties = null, $id = null, ... $args)
+    public function __construct(?Geometry $geometry = null, ?array $properties = null, $id = null, ...$args)
     {
         $this->geometry = $geometry;
         $this->properties = $properties;
@@ -83,7 +85,7 @@ class Feature extends GeoJson
         $json['properties'] = $this->properties ?? null;
 
         // Ensure empty associative arrays are encoded as JSON objects
-        if ($json['properties'] === array()) {
+        if ($json['properties'] === []) {
             $json['properties'] = new stdClass();
         }
 

--- a/src/GeoJson/Feature/Feature.php
+++ b/src/GeoJson/Feature/Feature.php
@@ -2,6 +2,8 @@
 
 namespace GeoJson\Feature;
 
+use GeoJson\BoundingBox;
+use GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem;
 use GeoJson\GeoJson;
 use GeoJson\Geometry\Geometry;
 use stdClass;
@@ -36,17 +38,15 @@ class Feature extends GeoJson
 
     /**
      * @param int|string|null $id
-     * @param CoordinateResolutionSystem|BoundingBox $arg,...
+     * @param CoordinateReferenceSystem|BoundingBox $args
      */
-    public function __construct(?Geometry $geometry = null, ?array $properties = null, $id = null)
+    public function __construct(?Geometry $geometry = null, ?array $properties = null, $id = null, ... $args)
     {
         $this->geometry = $geometry;
         $this->properties = $properties;
         $this->id = $id;
 
-        if (func_num_args() > 3) {
-            $this->setOptionalConstructorArgs(array_slice(func_get_args(), 3));
-        }
+        $this->setOptionalConstructorArgs($args);
     }
 
     /**

--- a/src/GeoJson/Feature/Feature.php
+++ b/src/GeoJson/Feature/Feature.php
@@ -14,36 +14,31 @@ use stdClass;
  */
 class Feature extends GeoJson
 {
-    protected $type = 'Feature';
+    protected string $type = 'Feature';
 
-    /**
-     * @var Geometry
-     */
-    protected $geometry;
+    protected ?Geometry $geometry;
 
     /**
      * Properties are a JSON object, which corresponds to an associative array, or null.
      *
      * @see https://www.rfc-editor.org/rfc/rfc7946#section-3.2
-     *
-     * @var array|null
      */
-    protected $properties;
+    protected ?array $properties;
 
     /**
-     * @var mixed
+     * The identifier is either a JSON string or a number.
+     *
+     * @see https://www.rfc-editor.org/rfc/rfc7946#section-3.2
+     *
+     * @var int|string|null
      */
     protected $id;
 
     /**
-     * Constructor.
-     *
-     * @param Geometry $geometry
-     * @param array $properties
-     * @param mixed $id
+     * @param int|string|null $id
      * @param CoordinateResolutionSystem|BoundingBox $arg,...
      */
-    public function __construct(Geometry $geometry = null, array $properties = null, $id = null)
+    public function __construct(?Geometry $geometry = null, ?array $properties = null, $id = null)
     {
         $this->geometry = $geometry;
         $this->properties = $properties;
@@ -56,10 +51,8 @@ class Feature extends GeoJson
 
     /**
      * Return the Geometry object for this Feature object.
-     *
-     * @return Geometry
      */
-    public function getGeometry()
+    public function getGeometry(): ?Geometry
     {
         return $this->geometry;
     }
@@ -67,7 +60,7 @@ class Feature extends GeoJson
     /**
      * Return the identifier for this Feature object.
      *
-     * @return mixed
+     * @return int|string|null
      */
     public function getId()
     {
@@ -76,10 +69,8 @@ class Feature extends GeoJson
 
     /**
      * Return the properties for this Feature object.
-     *
-     * @return array|null
      */
-    public function getProperties()
+    public function getProperties(): ?array
     {
         return $this->properties;
     }
@@ -89,7 +80,7 @@ class Feature extends GeoJson
         $json = parent::jsonSerialize();
 
         $json['geometry'] = isset($this->geometry) ? $this->geometry->jsonSerialize() : null;
-        $json['properties'] = isset($this->properties) ? $this->properties : null;
+        $json['properties'] = $this->properties ?? null;
 
         // Ensure empty associative arrays are encoded as JSON objects
         if ($json['properties'] === array()) {

--- a/src/GeoJson/Feature/Feature.php
+++ b/src/GeoJson/Feature/Feature.php
@@ -84,9 +84,6 @@ class Feature extends GeoJson
         return $this->properties;
     }
 
-    /**
-     * @see http://php.net/manual/en/jsonserializable.jsonserialize.php
-     */
     public function jsonSerialize(): array
     {
         $json = parent::jsonSerialize();

--- a/src/GeoJson/Feature/FeatureCollection.php
+++ b/src/GeoJson/Feature/FeatureCollection.php
@@ -45,9 +45,6 @@ class FeatureCollection extends GeoJson implements Countable, IteratorAggregate
         }
     }
 
-    /**
-     * @see http://php.net/manual/en/countable.count.php
-     */
     public function count(): int
     {
         return count($this->features);
@@ -63,17 +60,11 @@ class FeatureCollection extends GeoJson implements Countable, IteratorAggregate
         return $this->features;
     }
 
-    /**
-     * @see http://php.net/manual/en/iteratoraggregate.getiterator.php
-     */
     public function getIterator(): Traversable
     {
         return new ArrayIterator($this->features);
     }
 
-    /**
-     * @see http://php.net/manual/en/jsonserializable.jsonserialize.php
-     */
     public function jsonSerialize(): array
     {
         return array_merge(

--- a/src/GeoJson/Feature/FeatureCollection.php
+++ b/src/GeoJson/Feature/FeatureCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Feature;
 
 use ArrayIterator;
@@ -10,6 +12,11 @@ use GeoJson\GeoJson;
 use InvalidArgumentException;
 use IteratorAggregate;
 use Traversable;
+
+use function array_values;
+use function count;
+use function array_merge;
+use function array_map;
 
 /**
  * Collection of Feature objects.
@@ -30,10 +37,10 @@ class FeatureCollection extends GeoJson implements Countable, IteratorAggregate
      * @param array<Feature> $features
      * @param CoordinateReferenceSystem|BoundingBox $args
      */
-    public function __construct(array $features, ... $args)
+    public function __construct(array $features, ...$args)
     {
         foreach ($features as $feature) {
-            if ( ! $feature instanceof Feature) {
+            if (! $feature instanceof Feature) {
                 throw new InvalidArgumentException('FeatureCollection may only contain Feature objects');
             }
         }
@@ -67,10 +74,10 @@ class FeatureCollection extends GeoJson implements Countable, IteratorAggregate
     {
         return array_merge(
             parent::jsonSerialize(),
-            array('features' => array_map(
-                function(Feature $feature) { return $feature->jsonSerialize(); },
+            ['features' => array_map(
+                static fn(Feature $feature) => $feature->jsonSerialize(),
                 $this->features
-            ))
+            )]
         );
     }
 }

--- a/src/GeoJson/Feature/FeatureCollection.php
+++ b/src/GeoJson/Feature/FeatureCollection.php
@@ -4,6 +4,8 @@ namespace GeoJson\Feature;
 
 use ArrayIterator;
 use Countable;
+use GeoJson\BoundingBox;
+use GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem;
 use GeoJson\GeoJson;
 use InvalidArgumentException;
 use IteratorAggregate;
@@ -26,9 +28,9 @@ class FeatureCollection extends GeoJson implements Countable, IteratorAggregate
 
     /**
      * @param array<Feature> $features
-     * @param CoordinateResolutionSystem|BoundingBox $arg,...
+     * @param CoordinateReferenceSystem|BoundingBox $args
      */
-    public function __construct(array $features)
+    public function __construct(array $features, ... $args)
     {
         foreach ($features as $feature) {
             if ( ! $feature instanceof Feature) {
@@ -38,9 +40,7 @@ class FeatureCollection extends GeoJson implements Countable, IteratorAggregate
 
         $this->features = array_values($features);
 
-        if (func_num_args() > 1) {
-            $this->setOptionalConstructorArgs(array_slice(func_get_args(), 1));
-        }
+        $this->setOptionalConstructorArgs($args);
     }
 
     public function count(): int

--- a/src/GeoJson/Feature/FeatureCollection.php
+++ b/src/GeoJson/Feature/FeatureCollection.php
@@ -2,7 +2,12 @@
 
 namespace GeoJson\Feature;
 
+use ArrayIterator;
+use Countable;
 use GeoJson\GeoJson;
+use InvalidArgumentException;
+use IteratorAggregate;
+use Traversable;
 
 /**
  * Collection of Feature objects.
@@ -10,7 +15,7 @@ use GeoJson\GeoJson;
  * @see http://www.geojson.org/geojson-spec.html#feature-collection-objects
  * @since 1.0
  */
-class FeatureCollection extends GeoJson implements \Countable, \IteratorAggregate
+class FeatureCollection extends GeoJson implements Countable, IteratorAggregate
 {
     protected $type = 'FeatureCollection';
 
@@ -29,7 +34,7 @@ class FeatureCollection extends GeoJson implements \Countable, \IteratorAggregat
     {
         foreach ($features as $feature) {
             if ( ! $feature instanceof Feature) {
-                throw new \InvalidArgumentException('FeatureCollection may only contain Feature objects');
+                throw new InvalidArgumentException('FeatureCollection may only contain Feature objects');
             }
         }
 
@@ -61,9 +66,9 @@ class FeatureCollection extends GeoJson implements \Countable, \IteratorAggregat
     /**
      * @see http://php.net/manual/en/iteratoraggregate.getiterator.php
      */
-    public function getIterator(): \Traversable
+    public function getIterator(): Traversable
     {
-        return new \ArrayIterator($this->features);
+        return new ArrayIterator($this->features);
     }
 
     /**

--- a/src/GeoJson/Feature/FeatureCollection.php
+++ b/src/GeoJson/Feature/FeatureCollection.php
@@ -17,17 +17,15 @@ use Traversable;
  */
 class FeatureCollection extends GeoJson implements Countable, IteratorAggregate
 {
-    protected $type = 'FeatureCollection';
+    protected string $type = 'FeatureCollection';
 
     /**
-     * @var array
+     * @var array<Feature>
      */
-    protected $features;
+    protected array $features;
 
     /**
-     * Constructor.
-     *
-     * @param Feature[] $features
+     * @param array<Feature> $features
      * @param CoordinateResolutionSystem|BoundingBox $arg,...
      */
     public function __construct(array $features)
@@ -53,9 +51,9 @@ class FeatureCollection extends GeoJson implements Countable, IteratorAggregate
     /**
      * Return the Feature objects in this collection.
      *
-     * @return Feature[]
+     * @return array<Feature>
      */
-    public function getFeatures()
+    public function getFeatures(): array
     {
         return $this->features;
     }

--- a/src/GeoJson/GeoJson.php
+++ b/src/GeoJson/GeoJson.php
@@ -94,20 +94,23 @@ abstract class GeoJson implements JsonSerializable, JsonUnserializable
                 break;
 
             case 'Feature':
-                $geometry = isset($json['geometry']) ? $json['geometry'] : null;
-                $properties = isset($json['properties']) ? $json['properties'] : null;
+                $geometry = $json['geometry'] ?? null;
+                $properties = $json['properties'] ?? null;
+                $id = $json['id'] ?? null;
 
-                if (isset($geometry) && ! is_array($geometry) && ! is_object($geometry)) {
+                if ($geometry !== null && ! is_array($geometry) && ! is_object($geometry)) {
                     throw UnserializationException::invalidProperty($type, 'geometry', $geometry, 'array or object');
                 }
 
-                if (isset($properties) && ! is_array($properties) && ! is_object($properties)) {
+                if ($properties !== null && ! is_array($properties) && ! is_object($properties)) {
                     throw UnserializationException::invalidProperty($type, 'properties', $properties, 'array or object');
                 }
 
-                $args[] = isset($geometry) ? self::jsonUnserialize($geometry) : null;
-                $args[] = isset($properties) ? (array) $properties : null;
-                $args[] = isset($json['id']) ? $json['id'] : null;
+                // TODO: Validate non-null $id as int or string in 2.0
+
+                $args[] = $geometry !== null ? self::jsonUnserialize($geometry) : null;
+                $args[] = $properties !== null ? (array) $properties : null;
+                $args[] = $id;
                 break;
 
             case 'FeatureCollection':

--- a/src/GeoJson/GeoJson.php
+++ b/src/GeoJson/GeoJson.php
@@ -6,7 +6,6 @@ use ArrayObject;
 use GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem;
 use GeoJson\Exception\UnserializationException;
 use JsonSerializable;
-use ReflectionClass;
 
 /**
  * Base GeoJson object.
@@ -148,9 +147,8 @@ abstract class GeoJson implements JsonSerializable, JsonUnserializable
         }
 
         $class = sprintf('GeoJson\%s\%s', (strncmp('Feature', $type, 7) === 0 ? 'Feature' : 'Geometry'), $type);
-        $class = new ReflectionClass($class);
 
-        return $class->newInstanceArgs($args);
+        return new $class(... $args);
     }
 
     /**

--- a/src/GeoJson/GeoJson.php
+++ b/src/GeoJson/GeoJson.php
@@ -2,8 +2,11 @@
 
 namespace GeoJson;
 
+use ArrayObject;
 use GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem;
 use GeoJson\Exception\UnserializationException;
+use JsonSerializable;
+use ReflectionClass;
 
 /**
  * Base GeoJson object.
@@ -11,7 +14,7 @@ use GeoJson\Exception\UnserializationException;
  * @see http://www.geojson.org/geojson-spec.html#geojson-objects
  * @since 1.0
  */
-abstract class GeoJson implements \JsonSerializable, JsonUnserializable
+abstract class GeoJson implements JsonSerializable, JsonUnserializable
 {
     /**
      * @var BoundingBox
@@ -85,7 +88,7 @@ abstract class GeoJson implements \JsonSerializable, JsonUnserializable
             throw UnserializationException::invalidValue('GeoJson', $json, 'array or object');
         }
 
-        $json = new \ArrayObject($json);
+        $json = new ArrayObject($json);
 
         if ( ! $json->offsetExists('type')) {
             throw UnserializationException::missingProperty('GeoJson', 'type', 'string');
@@ -166,7 +169,7 @@ abstract class GeoJson implements \JsonSerializable, JsonUnserializable
         }
 
         $class = sprintf('GeoJson\%s\%s', (strncmp('Feature', $type, 7) === 0 ? 'Feature' : 'Geometry'), $type);
-        $class = new \ReflectionClass($class);
+        $class = new ReflectionClass($class);
 
         return $class->newInstanceArgs($args);
     }

--- a/src/GeoJson/GeoJson.php
+++ b/src/GeoJson/GeoJson.php
@@ -61,9 +61,6 @@ abstract class GeoJson implements JsonSerializable, JsonUnserializable
         return $this->type;
     }
 
-    /**
-     * @see http://php.net/manual/en/jsonserializable.jsonserialize.php
-     */
     public function jsonSerialize(): array
     {
         $json = array('type' => $this->type);
@@ -79,9 +76,6 @@ abstract class GeoJson implements JsonSerializable, JsonUnserializable
         return $json;
     }
 
-    /**
-     * @see JsonUnserializable::jsonUnserialize()
-     */
     final public static function jsonUnserialize($json)
     {
         if ( ! is_array($json) && ! is_object($json)) {

--- a/src/GeoJson/GeoJson.php
+++ b/src/GeoJson/GeoJson.php
@@ -16,47 +16,32 @@ use ReflectionClass;
  */
 abstract class GeoJson implements JsonSerializable, JsonUnserializable
 {
-    /**
-     * @var BoundingBox
-     */
-    protected $boundingBox;
+    protected ?BoundingBox $boundingBox = null;
 
-    /**
-     * @var CoordinateReferenceSystem
-     */
-    protected $crs;
+    protected ?CoordinateReferenceSystem $crs = null;
 
-    /**
-     * @var string
-     */
-    protected $type;
+    protected string $type;
 
     /**
      * Return the BoundingBox for this GeoJson object.
-     *
-     * @return BoundingBox
      */
-    public function getBoundingBox()
+    public function getBoundingBox(): ?BoundingBox
     {
         return $this->boundingBox;
     }
 
     /**
      * Return the CoordinateReferenceSystem for this GeoJson object.
-     *
-     * @return CoordinateReferenceSystem
      */
-    public function getCrs()
+    public function getCrs(): ?CoordinateReferenceSystem
     {
         return $this->crs;
     }
 
     /**
      * Return the type for this GeoJson object.
-     *
-     * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }
@@ -76,7 +61,7 @@ abstract class GeoJson implements JsonSerializable, JsonUnserializable
         return $json;
     }
 
-    final public static function jsonUnserialize($json)
+    final public static function jsonUnserialize($json): self
     {
         if ( ! is_array($json) && ! is_object($json)) {
             throw UnserializationException::invalidValue('GeoJson', $json, 'array or object');
@@ -174,7 +159,7 @@ abstract class GeoJson implements JsonSerializable, JsonUnserializable
      * @todo Decide if multiple CRS or BoundingBox instances should override a
      *       previous value or be ignored
      */
-    protected function setOptionalConstructorArgs(array $args)
+    protected function setOptionalConstructorArgs(array $args): void
     {
         foreach ($args as $arg) {
             if ($arg instanceof CoordinateReferenceSystem) {

--- a/src/GeoJson/Geometry/Geometry.php
+++ b/src/GeoJson/Geometry/Geometry.php
@@ -27,9 +27,6 @@ abstract class Geometry extends GeoJson
         return $this->coordinates;
     }
 
-    /**
-     * @see http://php.net/manual/en/jsonserializable.jsonserialize.php
-     */
     public function jsonSerialize(): array
     {
         $json = parent::jsonSerialize();

--- a/src/GeoJson/Geometry/Geometry.php
+++ b/src/GeoJson/Geometry/Geometry.php
@@ -12,17 +12,12 @@ use GeoJson\GeoJson;
  */
 abstract class Geometry extends GeoJson
 {
-    /**
-     * @var array
-     */
-    protected $coordinates;
+    protected array $coordinates;
 
     /**
      * Return the coordinates for this Geometry object.
-     *
-     * @return array
      */
-    public function getCoordinates()
+    public function getCoordinates(): array
     {
         return $this->coordinates;
     }

--- a/src/GeoJson/Geometry/Geometry.php
+++ b/src/GeoJson/Geometry/Geometry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Geometry;
 
 use GeoJson\GeoJson;

--- a/src/GeoJson/Geometry/GeometryCollection.php
+++ b/src/GeoJson/Geometry/GeometryCollection.php
@@ -2,13 +2,19 @@
 
 namespace GeoJson\Geometry;
 
+use ArrayIterator;
+use Countable;
+use InvalidArgumentException;
+use IteratorAggregate;
+use Traversable;
+
 /**
  * Collection of Geometry objects.
  *
  * @see http://www.geojson.org/geojson-spec.html#geometry-collection
  * @since 1.0
  */
-class GeometryCollection extends Geometry implements \Countable, \IteratorAggregate
+class GeometryCollection extends Geometry implements Countable, IteratorAggregate
 {
     protected $type = 'GeometryCollection';
 
@@ -27,7 +33,7 @@ class GeometryCollection extends Geometry implements \Countable, \IteratorAggreg
     {
         foreach ($geometries as $geometry) {
             if ( ! $geometry instanceof Geometry) {
-                throw new \InvalidArgumentException('GeometryCollection may only contain Geometry objects');
+                throw new InvalidArgumentException('GeometryCollection may only contain Geometry objects');
             }
         }
 
@@ -59,9 +65,9 @@ class GeometryCollection extends Geometry implements \Countable, \IteratorAggreg
     /**
      * @see http://php.net/manual/en/iteratoraggregate.getiterator.php
      */
-    public function getIterator(): \Traversable
+    public function getIterator(): Traversable
     {
-        return new \ArrayIterator($this->geometries);
+        return new ArrayIterator($this->geometries);
     }
 
     /**

--- a/src/GeoJson/Geometry/GeometryCollection.php
+++ b/src/GeoJson/Geometry/GeometryCollection.php
@@ -4,6 +4,8 @@ namespace GeoJson\Geometry;
 
 use ArrayIterator;
 use Countable;
+use GeoJson\BoundingBox;
+use GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem;
 use InvalidArgumentException;
 use IteratorAggregate;
 use Traversable;
@@ -25,9 +27,9 @@ class GeometryCollection extends Geometry implements Countable, IteratorAggregat
 
     /**
      * @param array<Geometry> $geometries
-     * @param CoordinateResolutionSystem|BoundingBox $arg,...
+     * @param CoordinateReferenceSystem|BoundingBox $args
      */
-    public function __construct(array $geometries)
+    public function __construct(array $geometries, ... $args)
     {
         foreach ($geometries as $geometry) {
             if ( ! $geometry instanceof Geometry) {
@@ -37,9 +39,7 @@ class GeometryCollection extends Geometry implements Countable, IteratorAggregat
 
         $this->geometries = array_values($geometries);
 
-        if (func_num_args() > 1) {
-            $this->setOptionalConstructorArgs(array_slice(func_get_args(), 1));
-        }
+        $this->setOptionalConstructorArgs($args);
     }
 
     public function count(): int

--- a/src/GeoJson/Geometry/GeometryCollection.php
+++ b/src/GeoJson/Geometry/GeometryCollection.php
@@ -16,17 +16,15 @@ use Traversable;
  */
 class GeometryCollection extends Geometry implements Countable, IteratorAggregate
 {
-    protected $type = 'GeometryCollection';
+    protected string $type = 'GeometryCollection';
 
     /**
-     * @var array
+     * @var array<Geometry>
      */
-    protected $geometries;
+    protected array $geometries;
 
     /**
-     * Constructor.
-     *
-     * @param Geometry[] $geometries
+     * @param array<Geometry> $geometries
      * @param CoordinateResolutionSystem|BoundingBox $arg,...
      */
     public function __construct(array $geometries)
@@ -52,9 +50,9 @@ class GeometryCollection extends Geometry implements Countable, IteratorAggregat
     /**
      * Return the Geometry objects in this collection.
      *
-     * @return Geometry[]
+     * @return array<Geometry>
      */
-    public function getGeometries()
+    public function getGeometries(): array
     {
         return $this->geometries;
     }

--- a/src/GeoJson/Geometry/GeometryCollection.php
+++ b/src/GeoJson/Geometry/GeometryCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Geometry;
 
 use ArrayIterator;
@@ -9,6 +11,11 @@ use GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem;
 use InvalidArgumentException;
 use IteratorAggregate;
 use Traversable;
+
+use function array_values;
+use function count;
+use function array_merge;
+use function array_map;
 
 /**
  * Collection of Geometry objects.
@@ -29,10 +36,10 @@ class GeometryCollection extends Geometry implements Countable, IteratorAggregat
      * @param array<Geometry> $geometries
      * @param CoordinateReferenceSystem|BoundingBox $args
      */
-    public function __construct(array $geometries, ... $args)
+    public function __construct(array $geometries, ...$args)
     {
         foreach ($geometries as $geometry) {
-            if ( ! $geometry instanceof Geometry) {
+            if (! $geometry instanceof Geometry) {
                 throw new InvalidArgumentException('GeometryCollection may only contain Geometry objects');
             }
         }
@@ -66,10 +73,10 @@ class GeometryCollection extends Geometry implements Countable, IteratorAggregat
     {
         return array_merge(
             parent::jsonSerialize(),
-            array('geometries' => array_map(
-                function(Geometry $geometry) { return $geometry->jsonSerialize(); },
+            ['geometries' => array_map(
+                static fn(Geometry $geometry) => $geometry->jsonSerialize(),
                 $this->geometries
-            ))
+            )]
         );
     }
 }

--- a/src/GeoJson/Geometry/GeometryCollection.php
+++ b/src/GeoJson/Geometry/GeometryCollection.php
@@ -44,9 +44,6 @@ class GeometryCollection extends Geometry implements Countable, IteratorAggregat
         }
     }
 
-    /**
-     * @see http://php.net/manual/en/countable.count.php
-     */
     public function count(): int
     {
         return count($this->geometries);
@@ -62,17 +59,11 @@ class GeometryCollection extends Geometry implements Countable, IteratorAggregat
         return $this->geometries;
     }
 
-    /**
-     * @see http://php.net/manual/en/iteratoraggregate.getiterator.php
-     */
     public function getIterator(): Traversable
     {
         return new ArrayIterator($this->geometries);
     }
 
-    /**
-     * @see http://php.net/manual/en/jsonserializable.jsonserialize.php
-     */
     public function jsonSerialize(): array
     {
         return array_merge(

--- a/src/GeoJson/Geometry/LineString.php
+++ b/src/GeoJson/Geometry/LineString.php
@@ -2,6 +2,8 @@
 
 namespace GeoJson\Geometry;
 
+use GeoJson\BoundingBox;
+use GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem;
 use InvalidArgumentException;
 
 /**
@@ -18,14 +20,14 @@ class LineString extends MultiPoint
 
     /**
      * @param array<Point|array<float|int>> $positions
-     * @param CoordinateResolutionSystem|BoundingBox $arg,...
+     * @param CoordinateReferenceSystem|BoundingBox $args
      */
-    public function __construct(array $positions)
+    public function __construct(array $positions, ... $args)
     {
         if (count($positions) < 2) {
             throw new InvalidArgumentException('LineString requires at least two positions');
         }
 
-        call_user_func_array(array('parent', '__construct'), func_get_args());
+        parent::__construct($positions, ... $args);
     }
 }

--- a/src/GeoJson/Geometry/LineString.php
+++ b/src/GeoJson/Geometry/LineString.php
@@ -2,6 +2,8 @@
 
 namespace GeoJson\Geometry;
 
+use InvalidArgumentException;
+
 /**
  * LineString geometry object.
  *
@@ -23,7 +25,7 @@ class LineString extends MultiPoint
     public function __construct(array $positions)
     {
         if (count($positions) < 2) {
-            throw new \InvalidArgumentException('LineString requires at least two positions');
+            throw new InvalidArgumentException('LineString requires at least two positions');
         }
 
         call_user_func_array(array('parent', '__construct'), func_get_args());

--- a/src/GeoJson/Geometry/LineString.php
+++ b/src/GeoJson/Geometry/LineString.php
@@ -14,12 +14,10 @@ use InvalidArgumentException;
  */
 class LineString extends MultiPoint
 {
-    protected $type = 'LineString';
+    protected string $type = 'LineString';
 
     /**
-     * Constructor.
-     *
-     * @param float[][]|Point[] $positions
+     * @param array<Point|array<float|int>> $positions
      * @param CoordinateResolutionSystem|BoundingBox $arg,...
      */
     public function __construct(array $positions)

--- a/src/GeoJson/Geometry/LineString.php
+++ b/src/GeoJson/Geometry/LineString.php
@@ -1,10 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Geometry;
 
 use GeoJson\BoundingBox;
 use GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem;
 use InvalidArgumentException;
+
+use function count;
 
 /**
  * LineString geometry object.
@@ -22,7 +26,7 @@ class LineString extends MultiPoint
      * @param array<Point|array<float|int>> $positions
      * @param CoordinateReferenceSystem|BoundingBox $args
      */
-    public function __construct(array $positions, ... $args)
+    public function __construct(array $positions, ...$args)
     {
         if (count($positions) < 2) {
             throw new InvalidArgumentException('LineString requires at least two positions');

--- a/src/GeoJson/Geometry/LinearRing.php
+++ b/src/GeoJson/Geometry/LinearRing.php
@@ -2,6 +2,8 @@
 
 namespace GeoJson\Geometry;
 
+use GeoJson\BoundingBox;
+use GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem;
 use InvalidArgumentException;
 
 /**
@@ -17,9 +19,9 @@ class LinearRing extends LineString
 {
     /**
      * @param array<Point|array<int|float>> $positions
-     * @param CoordinateResolutionSystem|BoundingBox $arg,...
+     * @param CoordinateReferenceSystem|BoundingBox $args
      */
-    public function __construct(array $positions)
+    public function __construct(array $positions, ... $args)
     {
         if (count($positions) < 4) {
             throw new InvalidArgumentException('LinearRing requires at least four positions');
@@ -35,6 +37,6 @@ class LinearRing extends LineString
             throw new InvalidArgumentException('LinearRing requires the first and last positions to be equivalent');
         }
 
-        call_user_func_array(array('parent', '__construct'), func_get_args());
+        parent::__construct($positions, ... $args);
     }
 }

--- a/src/GeoJson/Geometry/LinearRing.php
+++ b/src/GeoJson/Geometry/LinearRing.php
@@ -16,9 +16,7 @@ use InvalidArgumentException;
 class LinearRing extends LineString
 {
     /**
-     * Constructor.
-     *
-     * @param float[][]|Point[] $positions
+     * @param array<Point|array<int|float>> $positions
      * @param CoordinateResolutionSystem|BoundingBox $arg,...
      */
     public function __construct(array $positions)

--- a/src/GeoJson/Geometry/LinearRing.php
+++ b/src/GeoJson/Geometry/LinearRing.php
@@ -2,6 +2,8 @@
 
 namespace GeoJson\Geometry;
 
+use InvalidArgumentException;
+
 /**
  * LinearRing is a special kind of LineString geometry object.
  *
@@ -22,7 +24,7 @@ class LinearRing extends LineString
     public function __construct(array $positions)
     {
         if (count($positions) < 4) {
-            throw new \InvalidArgumentException('LinearRing requires at least four positions');
+            throw new InvalidArgumentException('LinearRing requires at least four positions');
         }
 
         $lastPosition = end($positions);
@@ -32,7 +34,7 @@ class LinearRing extends LineString
         $firstPosition = $firstPosition instanceof Point ? $firstPosition->getCoordinates() : $firstPosition;
 
         if ($lastPosition !== $firstPosition) {
-            throw new \InvalidArgumentException('LinearRing requires the first and last positions to be equivalent');
+            throw new InvalidArgumentException('LinearRing requires the first and last positions to be equivalent');
         }
 
         call_user_func_array(array('parent', '__construct'), func_get_args());

--- a/src/GeoJson/Geometry/LinearRing.php
+++ b/src/GeoJson/Geometry/LinearRing.php
@@ -1,10 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Geometry;
 
 use GeoJson\BoundingBox;
 use GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem;
 use InvalidArgumentException;
+
+use function count;
+use function end;
+use function reset;
 
 /**
  * LinearRing is a special kind of LineString geometry object.
@@ -21,7 +27,7 @@ class LinearRing extends LineString
      * @param array<Point|array<int|float>> $positions
      * @param CoordinateReferenceSystem|BoundingBox $args
      */
-    public function __construct(array $positions, ... $args)
+    public function __construct(array $positions, ...$args)
     {
         if (count($positions) < 4) {
             throw new InvalidArgumentException('LinearRing requires at least four positions');

--- a/src/GeoJson/Geometry/MultiLineString.php
+++ b/src/GeoJson/Geometry/MultiLineString.php
@@ -12,12 +12,10 @@ namespace GeoJson\Geometry;
  */
 class MultiLineString extends Geometry
 {
-    protected $type = 'MultiLineString';
+    protected string $type = 'MultiLineString';
 
     /**
-     * Constructor.
-     *
-     * @param float[][][]|LineString[] $lineStrings
+     * @param array<LineString|array<Point|array<int|float>>> $lineStrings
      * @param CoordinateResolutionSystem|BoundingBox $arg,...
      */
     public function __construct(array $lineStrings)

--- a/src/GeoJson/Geometry/MultiLineString.php
+++ b/src/GeoJson/Geometry/MultiLineString.php
@@ -1,9 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Geometry;
 
 use GeoJson\BoundingBox;
 use GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem;
+
+use function array_map;
 
 /**
  * MultiLineString geometry object.
@@ -21,11 +25,11 @@ class MultiLineString extends Geometry
      * @param array<LineString|array<Point|array<int|float>>> $lineStrings
      * @param CoordinateReferenceSystem|BoundingBox $args
      */
-    public function __construct(array $lineStrings, ... $args)
+    public function __construct(array $lineStrings, ...$args)
     {
         $this->coordinates = array_map(
-            function($lineString) {
-                if ( ! $lineString instanceof LineString) {
+            static function ($lineString) {
+                if (! $lineString instanceof LineString) {
                     $lineString = new LineString($lineString);
                 }
 

--- a/src/GeoJson/Geometry/MultiLineString.php
+++ b/src/GeoJson/Geometry/MultiLineString.php
@@ -2,6 +2,9 @@
 
 namespace GeoJson\Geometry;
 
+use GeoJson\BoundingBox;
+use GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem;
+
 /**
  * MultiLineString geometry object.
  *
@@ -16,9 +19,9 @@ class MultiLineString extends Geometry
 
     /**
      * @param array<LineString|array<Point|array<int|float>>> $lineStrings
-     * @param CoordinateResolutionSystem|BoundingBox $arg,...
+     * @param CoordinateReferenceSystem|BoundingBox $args
      */
-    public function __construct(array $lineStrings)
+    public function __construct(array $lineStrings, ... $args)
     {
         $this->coordinates = array_map(
             function($lineString) {
@@ -31,8 +34,6 @@ class MultiLineString extends Geometry
             $lineStrings
         );
 
-        if (func_num_args() > 1) {
-            $this->setOptionalConstructorArgs(array_slice(func_get_args(), 1));
-        }
+        $this->setOptionalConstructorArgs($args);
     }
 }

--- a/src/GeoJson/Geometry/MultiPoint.php
+++ b/src/GeoJson/Geometry/MultiPoint.php
@@ -2,6 +2,9 @@
 
 namespace GeoJson\Geometry;
 
+use GeoJson\BoundingBox;
+use GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem;
+
 /**
  * MultiPoint geometry object.
  *
@@ -16,9 +19,9 @@ class MultiPoint extends Geometry
 
     /**
      * @param array<Point|array<float|int>> $positions
-     * @param CoordinateResolutionSystem|BoundingBox $arg,...
+     * @param CoordinateReferenceSystem|BoundingBox $args
      */
-    public function __construct(array $positions)
+    public function __construct(array $positions, ... $args)
     {
         $this->coordinates = array_map(
             function($point) {
@@ -31,8 +34,6 @@ class MultiPoint extends Geometry
             $positions
         );
 
-        if (func_num_args() > 1) {
-            $this->setOptionalConstructorArgs(array_slice(func_get_args(), 1));
-        }
+        $this->setOptionalConstructorArgs($args);
     }
 }

--- a/src/GeoJson/Geometry/MultiPoint.php
+++ b/src/GeoJson/Geometry/MultiPoint.php
@@ -12,12 +12,10 @@ namespace GeoJson\Geometry;
  */
 class MultiPoint extends Geometry
 {
-    protected $type = 'MultiPoint';
+    protected string $type = 'MultiPoint';
 
     /**
-     * Constructor.
-     *
-     * @param float[][]|Point[] $positions
+     * @param array<Point|array<float|int>> $positions
      * @param CoordinateResolutionSystem|BoundingBox $arg,...
      */
     public function __construct(array $positions)

--- a/src/GeoJson/Geometry/MultiPoint.php
+++ b/src/GeoJson/Geometry/MultiPoint.php
@@ -1,9 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Geometry;
 
 use GeoJson\BoundingBox;
 use GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem;
+
+use function array_map;
 
 /**
  * MultiPoint geometry object.
@@ -21,11 +25,11 @@ class MultiPoint extends Geometry
      * @param array<Point|array<float|int>> $positions
      * @param CoordinateReferenceSystem|BoundingBox $args
      */
-    public function __construct(array $positions, ... $args)
+    public function __construct(array $positions, ...$args)
     {
         $this->coordinates = array_map(
-            function($point) {
-                if ( ! $point instanceof Point) {
+            static function ($point) {
+                if (! $point instanceof Point) {
                     $point = new Point($point);
                 }
 

--- a/src/GeoJson/Geometry/MultiPolygon.php
+++ b/src/GeoJson/Geometry/MultiPolygon.php
@@ -1,9 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Geometry;
 
 use GeoJson\BoundingBox;
 use GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem;
+
+use function array_map;
 
 /**
  * MultiPolygon geometry object.
@@ -21,11 +25,11 @@ class MultiPolygon extends Geometry
      * @param array<Polygon|array<LinearRing|array<Point|array<int|float>>>> $polygons
      * @param CoordinateReferenceSystem|BoundingBox $args
      */
-    public function __construct(array $polygons, ... $args)
+    public function __construct(array $polygons, ...$args)
     {
         $this->coordinates = array_map(
-            function($polygon) {
-                if ( ! $polygon instanceof Polygon) {
+            static function ($polygon) {
+                if (! $polygon instanceof Polygon) {
                     $polygon = new Polygon($polygon);
                 }
 

--- a/src/GeoJson/Geometry/MultiPolygon.php
+++ b/src/GeoJson/Geometry/MultiPolygon.php
@@ -2,6 +2,9 @@
 
 namespace GeoJson\Geometry;
 
+use GeoJson\BoundingBox;
+use GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem;
+
 /**
  * MultiPolygon geometry object.
  *
@@ -16,9 +19,9 @@ class MultiPolygon extends Geometry
 
     /**
      * @param array<Polygon|array<LinearRing|array<Point|array<int|float>>>> $polygons
-     * @param CoordinateResolutionSystem|BoundingBox $arg,...
+     * @param CoordinateReferenceSystem|BoundingBox $args
      */
-    public function __construct(array $polygons)
+    public function __construct(array $polygons, ... $args)
     {
         $this->coordinates = array_map(
             function($polygon) {
@@ -31,8 +34,6 @@ class MultiPolygon extends Geometry
             $polygons
         );
 
-        if (func_num_args() > 1) {
-            $this->setOptionalConstructorArgs(array_slice(func_get_args(), 1));
-        }
+        $this->setOptionalConstructorArgs($args);
     }
 }

--- a/src/GeoJson/Geometry/MultiPolygon.php
+++ b/src/GeoJson/Geometry/MultiPolygon.php
@@ -12,12 +12,10 @@ namespace GeoJson\Geometry;
  */
 class MultiPolygon extends Geometry
 {
-    protected $type = 'MultiPolygon';
+    protected string $type = 'MultiPolygon';
 
     /**
-     * Constructor.
-     *
-     * @param float[][][][]|Polygon[] $polygons
+     * @param array<Polygon|array<LinearRing|array<Point|array<int|float>>>> $polygons
      * @param CoordinateResolutionSystem|BoundingBox $arg,...
      */
     public function __construct(array $polygons)

--- a/src/GeoJson/Geometry/Point.php
+++ b/src/GeoJson/Geometry/Point.php
@@ -2,6 +2,8 @@
 
 namespace GeoJson\Geometry;
 
+use InvalidArgumentException;
+
 /**
  * Point geometry object.
  *
@@ -23,12 +25,12 @@ class Point extends Geometry
     public function __construct(array $position)
     {
         if (count($position) < 2) {
-            throw new \InvalidArgumentException('Position requires at least two elements');
+            throw new InvalidArgumentException('Position requires at least two elements');
         }
 
         foreach ($position as $value) {
             if ( ! is_int($value) && ! is_float($value)) {
-                throw new \InvalidArgumentException('Position elements must be integers or floats');
+                throw new InvalidArgumentException('Position elements must be integers or floats');
             }
         }
 

--- a/src/GeoJson/Geometry/Point.php
+++ b/src/GeoJson/Geometry/Point.php
@@ -14,12 +14,10 @@ use InvalidArgumentException;
  */
 class Point extends Geometry
 {
-    protected $type = 'Point';
+    protected string $type = 'Point';
 
     /**
-     * Constructor.
-     *
-     * @param float[] $position
+     * @param array<float|int> $position
      * @param CoordinateResolutionSystem|BoundingBox $arg,...
      */
     public function __construct(array $position)

--- a/src/GeoJson/Geometry/Point.php
+++ b/src/GeoJson/Geometry/Point.php
@@ -1,10 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Geometry;
 
 use GeoJson\BoundingBox;
 use GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem;
 use InvalidArgumentException;
+
+use function count;
+use function is_int;
+use function is_float;
 
 /**
  * Point geometry object.
@@ -22,14 +28,14 @@ class Point extends Geometry
      * @param array<float|int> $position
      * @param CoordinateReferenceSystem|BoundingBox $args
      */
-    public function __construct(array $position, ... $args)
+    public function __construct(array $position, ...$args)
     {
         if (count($position) < 2) {
             throw new InvalidArgumentException('Position requires at least two elements');
         }
 
         foreach ($position as $value) {
-            if ( ! is_int($value) && ! is_float($value)) {
+            if (! is_int($value) && ! is_float($value)) {
                 throw new InvalidArgumentException('Position elements must be integers or floats');
             }
         }

--- a/src/GeoJson/Geometry/Point.php
+++ b/src/GeoJson/Geometry/Point.php
@@ -2,6 +2,8 @@
 
 namespace GeoJson\Geometry;
 
+use GeoJson\BoundingBox;
+use GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem;
 use InvalidArgumentException;
 
 /**
@@ -18,9 +20,9 @@ class Point extends Geometry
 
     /**
      * @param array<float|int> $position
-     * @param CoordinateResolutionSystem|BoundingBox $arg,...
+     * @param CoordinateReferenceSystem|BoundingBox $args
      */
-    public function __construct(array $position)
+    public function __construct(array $position, ... $args)
     {
         if (count($position) < 2) {
             throw new InvalidArgumentException('Position requires at least two elements');
@@ -34,8 +36,6 @@ class Point extends Geometry
 
         $this->coordinates = $position;
 
-        if (func_num_args() > 1) {
-            $this->setOptionalConstructorArgs(array_slice(func_get_args(), 1));
-        }
+        $this->setOptionalConstructorArgs($args);
     }
 }

--- a/src/GeoJson/Geometry/Polygon.php
+++ b/src/GeoJson/Geometry/Polygon.php
@@ -12,12 +12,10 @@ namespace GeoJson\Geometry;
  */
 class Polygon extends Geometry
 {
-    protected $type = 'Polygon';
+    protected string $type = 'Polygon';
 
     /**
-     * Constructor.
-     *
-     * @param float[][][]|LinearRing[] $linearRings
+     * @param array<LinearRing|array<Point|array<int|float>>> $linearRings
      * @param CoordinateResolutionSystem|BoundingBox $arg,...
      */
     public function __construct(array $linearRings)

--- a/src/GeoJson/Geometry/Polygon.php
+++ b/src/GeoJson/Geometry/Polygon.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Geometry;
 
 use GeoJson\BoundingBox;
@@ -21,10 +23,10 @@ class Polygon extends Geometry
      * @param array<LinearRing|array<Point|array<int|float>>> $linearRings
      * @param CoordinateReferenceSystem|BoundingBox $args
      */
-    public function __construct(array $linearRings, ... $args)
+    public function __construct(array $linearRings, ...$args)
     {
         foreach ($linearRings as $linearRing) {
-            if ( ! $linearRing instanceof LinearRing) {
+            if (! $linearRing instanceof LinearRing) {
                 $linearRing = new LinearRing($linearRing);
             }
             $this->coordinates[] = $linearRing->getCoordinates();

--- a/src/GeoJson/Geometry/Polygon.php
+++ b/src/GeoJson/Geometry/Polygon.php
@@ -2,6 +2,9 @@
 
 namespace GeoJson\Geometry;
 
+use GeoJson\BoundingBox;
+use GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem;
+
 /**
  * Polygon geometry object.
  *
@@ -16,9 +19,9 @@ class Polygon extends Geometry
 
     /**
      * @param array<LinearRing|array<Point|array<int|float>>> $linearRings
-     * @param CoordinateResolutionSystem|BoundingBox $arg,...
+     * @param CoordinateReferenceSystem|BoundingBox $args
      */
-    public function __construct(array $linearRings)
+    public function __construct(array $linearRings, ... $args)
     {
         foreach ($linearRings as $linearRing) {
             if ( ! $linearRing instanceof LinearRing) {
@@ -27,8 +30,6 @@ class Polygon extends Geometry
             $this->coordinates[] = $linearRing->getCoordinates();
         }
 
-        if (func_num_args() > 1) {
-            $this->setOptionalConstructorArgs(array_slice(func_get_args(), 1));
-        }
+        $this->setOptionalConstructorArgs($args);
     }
 }

--- a/src/GeoJson/JsonUnserializable.php
+++ b/src/GeoJson/JsonUnserializable.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson;
 
 use GeoJson\Exception\UnserializationException;

--- a/tests/GeoJson/Tests/BaseGeoJsonTest.php
+++ b/tests/GeoJson/Tests/BaseGeoJsonTest.php
@@ -2,43 +2,43 @@
 
 namespace GeoJson\Tests;
 
-use PHPUnit\Framework\TestCase;
 use GeoJson\BoundingBox;
 use GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem;
 use GeoJson\Feature\Feature;
 use GeoJson\Geometry\Geometry;
+use PHPUnit\Framework\TestCase;
 
 abstract class BaseGeoJsonTest extends TestCase
 {
-    abstract public function createSubjectWithExtraArguments(array $extraArgs);
+    abstract public function createSubjectWithExtraArguments(... $extraArgs);
 
     public function testConstructorShouldScanExtraArgumentsForCrsAndBoundingBox()
     {
         $box = $this->getMockBoundingBox();
         $crs = $this->getMockCoordinateReferenceSystem();
 
-        $sut = $this->createSubjectWithExtraArguments(array());
+        $sut = $this->createSubjectWithExtraArguments();
         $this->assertNull($sut->getBoundingBox());
         $this->assertNull($sut->getCrs());
 
-        $sut = $this->createSubjectWithExtraArguments(array($box));
+        $sut = $this->createSubjectWithExtraArguments($box);
         $this->assertSame($box, $sut->getBoundingBox());
         $this->assertNull($sut->getCrs());
 
-        $sut = $this->createSubjectWithExtraArguments(array($crs));
+        $sut = $this->createSubjectWithExtraArguments($crs);
         $this->assertNull($sut->getBoundingBox());
         $this->assertSame($crs, $sut->getCrs());
 
-        $sut = $this->createSubjectWithExtraArguments(array($box, $crs));
+        $sut = $this->createSubjectWithExtraArguments($box, $crs);
         $this->assertSame($box, $sut->getBoundingBox());
         $this->assertSame($crs, $sut->getCrs());
 
-        $sut = $this->createSubjectWithExtraArguments(array($crs, $box));
+        $sut = $this->createSubjectWithExtraArguments($crs, $box);
         $this->assertSame($box, $sut->getBoundingBox());
         $this->assertSame($crs, $sut->getCrs());
 
         // Not that you would, but you could…
-        $sut = $this->createSubjectWithExtraArguments(array(null, null, $box, $crs));
+        $sut = $this->createSubjectWithExtraArguments(null, null, $box, $crs);
         $this->assertSame($box, $sut->getBoundingBox());
         $this->assertSame($crs, $sut->getCrs());
     }
@@ -51,7 +51,7 @@ abstract class BaseGeoJsonTest extends TestCase
         $crs = $this->getMockCoordinateReferenceSystem();
         $crs->method('jsonSerialize')->willReturn(['coordinateReferenceSystem']);
 
-        $sut = $this->createSubjectWithExtraArguments(array($box, $crs));
+        $sut = $this->createSubjectWithExtraArguments($box, $crs);
 
         $json = $sut->jsonSerialize();
 
@@ -63,29 +63,21 @@ abstract class BaseGeoJsonTest extends TestCase
 
     protected function getMockBoundingBox()
     {
-        return $this->getMockBuilder(BoundingBox::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(BoundingBox::class);
     }
 
     protected function getMockCoordinateReferenceSystem()
     {
-        return $this->getMockBuilder(CoordinateReferenceSystem::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(CoordinateReferenceSystem::class);
     }
 
     protected function getMockFeature()
     {
-        return $this->getMockBuilder(Feature::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(Feature::class);
     }
 
     protected function getMockGeometry()
     {
-        return $this->getMockBuilder(Geometry::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(Geometry::class);
     }
 }

--- a/tests/GeoJson/Tests/BaseGeoJsonTest.php
+++ b/tests/GeoJson/Tests/BaseGeoJsonTest.php
@@ -46,15 +46,10 @@ abstract class BaseGeoJsonTest extends TestCase
     public function testSerializationWithCrsAndBoundingBox()
     {
         $box = $this->getMockBoundingBox();
+        $box->method('jsonSerialize')->willReturn(['boundingBox']);
+
         $crs = $this->getMockCoordinateReferenceSystem();
-
-        $box->expects($this->any())
-            ->method('jsonSerialize')
-            ->will($this->returnValue(['boundingBox']));
-
-        $crs->expects($this->any())
-            ->method('jsonSerialize')
-            ->will($this->returnValue(['coordinateReferenceSystem']));
+        $crs->method('jsonSerialize')->willReturn(['coordinateReferenceSystem']);
 
         $sut = $this->createSubjectWithExtraArguments(array($box, $crs));
 

--- a/tests/GeoJson/Tests/BaseGeoJsonTest.php
+++ b/tests/GeoJson/Tests/BaseGeoJsonTest.php
@@ -10,9 +10,14 @@ use PHPUnit\Framework\TestCase;
 
 abstract class BaseGeoJsonTest extends TestCase
 {
-    abstract public function createSubjectWithExtraArguments(... $extraArgs);
+    /**
+     * @param ...$extraArgs
+     *
+     * @return mixed
+     */
+    abstract public function createSubjectWithExtraArguments(...$extraArgs);
 
-    public function testConstructorShouldScanExtraArgumentsForCrsAndBoundingBox()
+    public function testConstructorShouldScanExtraArgumentsForCrsAndBoundingBox(): void
     {
         $box = $this->getMockBoundingBox();
         $crs = $this->getMockCoordinateReferenceSystem();
@@ -43,7 +48,7 @@ abstract class BaseGeoJsonTest extends TestCase
         $this->assertSame($crs, $sut->getCrs());
     }
 
-    public function testSerializationWithCrsAndBoundingBox()
+    public function testSerializationWithCrsAndBoundingBox(): void
     {
         $box = $this->getMockBoundingBox();
         $box->method('jsonSerialize')->willReturn(['boundingBox']);

--- a/tests/GeoJson/Tests/BaseGeoJsonTest.php
+++ b/tests/GeoJson/Tests/BaseGeoJsonTest.php
@@ -3,6 +3,10 @@
 namespace GeoJson\Tests;
 
 use PHPUnit\Framework\TestCase;
+use GeoJson\BoundingBox;
+use GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem;
+use GeoJson\Feature\Feature;
+use GeoJson\Geometry\Geometry;
 
 abstract class BaseGeoJsonTest extends TestCase
 {
@@ -64,28 +68,28 @@ abstract class BaseGeoJsonTest extends TestCase
 
     protected function getMockBoundingBox()
     {
-        return $this->getMockBuilder('GeoJson\BoundingBox')
+        return $this->getMockBuilder(BoundingBox::class)
             ->disableOriginalConstructor()
             ->getMock();
     }
 
     protected function getMockCoordinateReferenceSystem()
     {
-        return $this->getMockBuilder('GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem')
+        return $this->getMockBuilder(CoordinateReferenceSystem::class)
             ->disableOriginalConstructor()
             ->getMock();
     }
 
     protected function getMockFeature()
     {
-        return $this->getMockBuilder('GeoJson\Feature\Feature')
+        return $this->getMockBuilder(Feature::class)
             ->disableOriginalConstructor()
             ->getMock();
     }
 
     protected function getMockGeometry()
     {
-        return $this->getMockBuilder('GeoJson\Geometry\Geometry')
+        return $this->getMockBuilder(Geometry::class)
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/tests/GeoJson/Tests/BaseGeoJsonTest.php
+++ b/tests/GeoJson/Tests/BaseGeoJsonTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Tests;
 
 use GeoJson\BoundingBox;

--- a/tests/GeoJson/Tests/BoundingBoxTest.php
+++ b/tests/GeoJson/Tests/BoundingBoxTest.php
@@ -4,9 +4,9 @@ namespace GeoJson\Tests;
 
 use GeoJson\BoundingBox;
 use GeoJson\Exception\UnserializationException;
+use GeoJson\JsonUnserializable;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
-use GeoJson\JsonUnserializable;
 use stdClass;
 
 class BoundingBoxTest extends TestCase

--- a/tests/GeoJson/Tests/BoundingBoxTest.php
+++ b/tests/GeoJson/Tests/BoundingBoxTest.php
@@ -7,6 +7,7 @@ use GeoJson\Exception\UnserializationException;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use GeoJson\JsonUnserializable;
+use stdClass;
 
 class BoundingBoxTest extends TestCase
 {
@@ -50,7 +51,7 @@ class BoundingBoxTest extends TestCase
     {
         return array(
             'strings' => array('0', '0.0', '1', '1.0'),
-            'objects' => array(new \stdClass(), new \stdClass(), new \stdClass(), new \stdClass()),
+            'objects' => array(new stdClass(), new stdClass(), new stdClass(), new stdClass()),
             'arrays' => array(array(), array(), array(), array()),
         );
     }
@@ -112,7 +113,7 @@ class BoundingBoxTest extends TestCase
             array(null),
             array(1),
             array('foo'),
-            array(new \stdClass()),
+            array(new stdClass()),
         );
     }
 }

--- a/tests/GeoJson/Tests/BoundingBoxTest.php
+++ b/tests/GeoJson/Tests/BoundingBoxTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Tests;
 
 use GeoJson\BoundingBox;
@@ -9,38 +11,41 @@ use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
+use function func_get_args;
+use function json_decode;
+
 class BoundingBoxTest extends TestCase
 {
-    public function testIsJsonSerializable()
+    public function testIsJsonSerializable(): void
     {
-        $this->assertInstanceOf('JsonSerializable', new BoundingBox(array(0, 0, 1, 1)));
+        $this->assertInstanceOf('JsonSerializable', new BoundingBox([0, 0, 1, 1]));
     }
 
-    public function testIsJsonUnserializable()
+    public function testIsJsonUnserializable(): void
     {
-        $this->assertInstanceOf(JsonUnserializable::class, new BoundingBox(array(0, 0, 1, 1)));
+        $this->assertInstanceOf(JsonUnserializable::class, new BoundingBox([0, 0, 1, 1]));
     }
 
-    public function testConstructorShouldRequireAtLeastFourValues()
+    public function testConstructorShouldRequireAtLeastFourValues(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('BoundingBox requires at least four values');
 
-        new BoundingBox(array(0, 0));
+        new BoundingBox([0, 0]);
     }
 
-    public function testConstructorShouldRequireAnEvenNumberOfValues()
+    public function testConstructorShouldRequireAnEvenNumberOfValues(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('BoundingBox requires an even number of values');
 
-        new BoundingBox(array(0, 0, 1, 1, 2));
+        new BoundingBox([0, 0, 1, 1, 2]);
     }
 
     /**
      * @dataProvider provideBoundsWithInvalidTypes
      */
-    public function testConstructorShouldRequireIntegerOrFloatValues()
+    public function testConstructorShouldRequireIntegerOrFloatValues(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('BoundingBox values must be integers or floats');
@@ -49,24 +54,24 @@ class BoundingBoxTest extends TestCase
 
     public function provideBoundsWithInvalidTypes()
     {
-        return array(
-            'strings' => array('0', '0.0', '1', '1.0'),
-            'objects' => array(new stdClass(), new stdClass(), new stdClass(), new stdClass()),
-            'arrays' => array(array(), array(), array(), array()),
-        );
+        return [
+            'strings' => ['0', '0.0', '1', '1.0'],
+            'objects' => [new stdClass(), new stdClass(), new stdClass(), new stdClass()],
+            'arrays' => [[], [], [], []],
+        ];
     }
 
-    public function testConstructorShouldRequireMinBeforeMaxValues()
+    public function testConstructorShouldRequireMinBeforeMaxValues(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('BoundingBox min values must precede max values');
 
-        new BoundingBox(array(-90.0, -95.0, -92.5, 90.0));
+        new BoundingBox([-90.0, -95.0, -92.5, 90.0]);
     }
 
-    public function testSerialization()
+    public function testSerialization(): void
     {
-        $bounds = array(-180.0, -90.0, 0.0, 180.0, 90.0, 100.0);
+        $bounds = [-180.0, -90.0, 0.0, 180.0, 90.0, 100.0];
         $boundingBox = new BoundingBox($bounds);
 
         $this->assertSame($bounds, $boundingBox->getBounds());
@@ -77,7 +82,7 @@ class BoundingBoxTest extends TestCase
      * @dataProvider provideJsonDecodeAssocOptions
      * @group functional
      */
-    public function testUnserialization($assoc)
+    public function testUnserialization($assoc): void
     {
         $json = '[-180.0, -90.0, 180.0, 90.0]';
 
@@ -85,21 +90,21 @@ class BoundingBoxTest extends TestCase
         $boundingBox = BoundingBox::jsonUnserialize($json);
 
         $this->assertInstanceOf(BoundingBox::class, $boundingBox);
-        $this->assertSame(array(-180.0, -90.0, 180.0, 90.0), $boundingBox->getBounds());
+        $this->assertSame([-180.0, -90.0, 180.0, 90.0], $boundingBox->getBounds());
     }
 
     public function provideJsonDecodeAssocOptions()
     {
-        return array(
-            'assoc=true' => array(true),
-            'assoc=false' => array(false),
-        );
+        return [
+            'assoc=true' => [true],
+            'assoc=false' => [false],
+        ];
     }
 
     /**
      * @dataProvider provideInvalidUnserializationValues
      */
-    public function testUnserializationShouldRequireArray($value)
+    public function testUnserializationShouldRequireArray($value): void
     {
         $this->expectException(UnserializationException::class);
         $this->expectExceptionMessage('BoundingBox expected value of type array');
@@ -109,11 +114,11 @@ class BoundingBoxTest extends TestCase
 
     public function provideInvalidUnserializationValues()
     {
-        return array(
-            array(null),
-            array(1),
-            array('foo'),
-            array(new stdClass()),
-        );
+        return [
+            [null],
+            [1],
+            ['foo'],
+            [new stdClass()],
+        ];
     }
 }

--- a/tests/GeoJson/Tests/BoundingBoxTest.php
+++ b/tests/GeoJson/Tests/BoundingBoxTest.php
@@ -6,6 +6,7 @@ use GeoJson\BoundingBox;
 use GeoJson\Exception\UnserializationException;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use GeoJson\JsonUnserializable;
 
 class BoundingBoxTest extends TestCase
 {
@@ -16,7 +17,7 @@ class BoundingBoxTest extends TestCase
 
     public function testIsJsonUnserializable()
     {
-        $this->assertInstanceOf('GeoJson\JsonUnserializable', new BoundingBox(array(0, 0, 1, 1)));
+        $this->assertInstanceOf(JsonUnserializable::class, new BoundingBox(array(0, 0, 1, 1)));
     }
 
     public function testConstructorShouldRequireAtLeastFourValues()
@@ -82,7 +83,7 @@ class BoundingBoxTest extends TestCase
         $json = json_decode($json, $assoc);
         $boundingBox = BoundingBox::jsonUnserialize($json);
 
-        $this->assertInstanceOf('GeoJson\BoundingBox', $boundingBox);
+        $this->assertInstanceOf(BoundingBox::class, $boundingBox);
         $this->assertSame(array(-180.0, -90.0, 180.0, 90.0), $boundingBox->getBounds());
     }
 

--- a/tests/GeoJson/Tests/CoordinateReferenceSystem/CoordinateReferenceSystemTest.php
+++ b/tests/GeoJson/Tests/CoordinateReferenceSystem/CoordinateReferenceSystemTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Tests\CoordinateReferenceSystem;
 
 use GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem;
@@ -10,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 class CoordinateReferenceSystemTest extends TestCase
 {
-    public function testIsJsonSerializable()
+    public function testIsJsonSerializable(): void
     {
         $this->assertInstanceOf(
             JsonSerializable::class,
@@ -18,7 +20,7 @@ class CoordinateReferenceSystemTest extends TestCase
         );
     }
 
-    public function testIsJsonUnserializable()
+    public function testIsJsonUnserializable(): void
     {
         $this->assertInstanceOf(
             JsonUnserializable::class,
@@ -26,7 +28,7 @@ class CoordinateReferenceSystemTest extends TestCase
         );
     }
 
-    public function testUnserializationShouldRequireArrayOrObject()
+    public function testUnserializationShouldRequireArrayOrObject(): void
     {
         $this->expectException(UnserializationException::class);
         $this->expectExceptionMessage('CRS expected value of type array or object');
@@ -34,27 +36,27 @@ class CoordinateReferenceSystemTest extends TestCase
         CoordinateReferenceSystem::jsonUnserialize(null);
     }
 
-    public function testUnserializationShouldRequireTypeField()
+    public function testUnserializationShouldRequireTypeField(): void
     {
         $this->expectException(UnserializationException::class);
         $this->expectExceptionMessage('CRS expected "type" property of type string, none given');
 
-        CoordinateReferenceSystem::jsonUnserialize(array('properties' => array()));
+        CoordinateReferenceSystem::jsonUnserialize(['properties' => []]);
     }
 
-    public function testUnserializationShouldRequirePropertiesField()
+    public function testUnserializationShouldRequirePropertiesField(): void
     {
         $this->expectException(UnserializationException::class);
         $this->expectExceptionMessage('CRS expected "properties" property of type array or object, none given');
 
-        CoordinateReferenceSystem::jsonUnserialize(array('type' => 'foo'));
+        CoordinateReferenceSystem::jsonUnserialize(['type' => 'foo']);
     }
 
-    public function testUnserializationShouldRequireValidType()
+    public function testUnserializationShouldRequireValidType(): void
     {
         $this->expectException(UnserializationException::class);
         $this->expectExceptionMessage('Invalid CRS type "foo"');
 
-        CoordinateReferenceSystem::jsonUnserialize(array('type' => 'foo', 'properties' => array()));
+        CoordinateReferenceSystem::jsonUnserialize(['type' => 'foo', 'properties' => []]);
     }
 }

--- a/tests/GeoJson/Tests/CoordinateReferenceSystem/CoordinateReferenceSystemTest.php
+++ b/tests/GeoJson/Tests/CoordinateReferenceSystem/CoordinateReferenceSystemTest.php
@@ -4,6 +4,8 @@ namespace GeoJson\Tests\CoordinateReferenceSystem;
 
 use GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem;
 use GeoJson\Exception\UnserializationException;
+use GeoJson\JsonUnserializable;
+use JsonSerializable;
 use PHPUnit\Framework\TestCase;
 
 class CoordinateReferenceSystemTest extends TestCase
@@ -11,16 +13,16 @@ class CoordinateReferenceSystemTest extends TestCase
     public function testIsJsonSerializable()
     {
         $this->assertInstanceOf(
-            'JsonSerializable',
-            $this->createMock('GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem')
+            JsonSerializable::class,
+            $this->createMock(CoordinateReferenceSystem::class)
         );
     }
 
     public function testIsJsonUnserializable()
     {
         $this->assertInstanceOf(
-            'GeoJson\JsonUnserializable',
-            $this->createMock('GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem')
+            JsonUnserializable::class,
+            $this->createMock(CoordinateReferenceSystem::class)
         );
     }
 

--- a/tests/GeoJson/Tests/CoordinateReferenceSystem/LinkedTest.php
+++ b/tests/GeoJson/Tests/CoordinateReferenceSystem/LinkedTest.php
@@ -11,10 +11,7 @@ class LinkedTest extends TestCase
 {
     public function testIsSubclassOfCoordinateReferenceSystem()
     {
-        $this->assertTrue(is_subclass_of(
-            'GeoJson\CoordinateReferenceSystem\Linked',
-            'GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem'
-        ));
+        $this->assertTrue(is_subclass_of(Linked::class, CoordinateReferenceSystem::class));
     }
 
     public function testSerialization()
@@ -72,7 +69,7 @@ JSON;
             'type' => 'proj4',
         );
 
-        $this->assertInstanceOf('GeoJson\CoordinateReferenceSystem\Linked', $crs);
+        $this->assertInstanceOf(Linked::class, $crs);
         $this->assertSame('link', $crs->getType());
         $this->assertSame($expectedProperties, $crs->getProperties());
     }
@@ -97,7 +94,7 @@ JSON;
 
         $expectedProperties = array('href' => 'http://example.com/crs/42');
 
-        $this->assertInstanceOf('GeoJson\CoordinateReferenceSystem\Linked', $crs);
+        $this->assertInstanceOf(Linked::class, $crs);
         $this->assertSame('link', $crs->getType());
         $this->assertSame($expectedProperties, $crs->getProperties());
     }

--- a/tests/GeoJson/Tests/CoordinateReferenceSystem/LinkedTest.php
+++ b/tests/GeoJson/Tests/CoordinateReferenceSystem/LinkedTest.php
@@ -16,12 +16,12 @@ class LinkedTest extends TestCase
 
     public function testSerialization()
     {
-        $crs = new Linked('http://example.com/crs/42', 'proj4');
+        $crs = new Linked('https://example.com/crs/42', 'proj4');
 
         $expected = array(
             'type' => 'link',
             'properties' => array(
-                'href' => 'http://example.com/crs/42',
+                'href' => 'https://example.com/crs/42',
                 'type' => 'proj4',
             ),
         );
@@ -33,12 +33,12 @@ class LinkedTest extends TestCase
 
     public function testSerializationWithoutHrefType()
     {
-        $crs = new Linked('http://example.com/crs/42');
+        $crs = new Linked('https://example.com/crs/42');
 
         $expected = array(
             'type' => 'link',
             'properties' => array(
-                'href' => 'http://example.com/crs/42',
+                'href' => 'https://example.com/crs/42',
             ),
         );
 
@@ -55,7 +55,7 @@ class LinkedTest extends TestCase
 {
     "type": "link",
     "properties": {
-        "href": "http://example.com/crs/42",
+        "href": "https://example.com/crs/42",
         "type": "proj4"
     }
 }
@@ -65,7 +65,7 @@ JSON;
         $crs = CoordinateReferenceSystem::jsonUnserialize($json);
 
         $expectedProperties = array(
-            'href' => 'http://example.com/crs/42',
+            'href' => 'https://example.com/crs/42',
             'type' => 'proj4',
         );
 
@@ -84,7 +84,7 @@ JSON;
 {
     "type": "link",
     "properties": {
-        "href": "http://example.com/crs/42"
+        "href": "https://example.com/crs/42"
     }
 }
 JSON;
@@ -92,7 +92,7 @@ JSON;
         $json = json_decode($json, $assoc);
         $crs = CoordinateReferenceSystem::jsonUnserialize($json);
 
-        $expectedProperties = array('href' => 'http://example.com/crs/42');
+        $expectedProperties = array('href' => 'https://example.com/crs/42');
 
         $this->assertInstanceOf(Linked::class, $crs);
         $this->assertSame('link', $crs->getType());

--- a/tests/GeoJson/Tests/CoordinateReferenceSystem/LinkedTest.php
+++ b/tests/GeoJson/Tests/CoordinateReferenceSystem/LinkedTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Tests\CoordinateReferenceSystem;
 
 use GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem;
@@ -7,40 +9,43 @@ use GeoJson\CoordinateReferenceSystem\Linked;
 use GeoJson\Exception\UnserializationException;
 use PHPUnit\Framework\TestCase;
 
+use function is_subclass_of;
+use function json_decode;
+
 class LinkedTest extends TestCase
 {
-    public function testIsSubclassOfCoordinateReferenceSystem()
+    public function testIsSubclassOfCoordinateReferenceSystem(): void
     {
         $this->assertTrue(is_subclass_of(Linked::class, CoordinateReferenceSystem::class));
     }
 
-    public function testSerialization()
+    public function testSerialization(): void
     {
         $crs = new Linked('https://example.com/crs/42', 'proj4');
 
-        $expected = array(
+        $expected = [
             'type' => 'link',
-            'properties' => array(
+            'properties' => [
                 'href' => 'https://example.com/crs/42',
                 'type' => 'proj4',
-            ),
-        );
+            ],
+        ];
 
         $this->assertSame('link', $crs->getType());
         $this->assertSame($expected['properties'], $crs->getProperties());
         $this->assertSame($expected, $crs->jsonSerialize());
     }
 
-    public function testSerializationWithoutHrefType()
+    public function testSerializationWithoutHrefType(): void
     {
         $crs = new Linked('https://example.com/crs/42');
 
-        $expected = array(
+        $expected = [
             'type' => 'link',
-            'properties' => array(
+            'properties' => [
                 'href' => 'https://example.com/crs/42',
-            ),
-        );
+            ],
+        ];
 
         $this->assertSame($expected, $crs->jsonSerialize());
     }
@@ -49,7 +54,7 @@ class LinkedTest extends TestCase
      * @dataProvider provideJsonDecodeAssocOptions
      * @group functional
      */
-    public function testUnserialization($assoc)
+    public function testUnserialization($assoc): void
     {
         $json = <<<'JSON'
 {
@@ -64,10 +69,10 @@ JSON;
         $json = json_decode($json, $assoc);
         $crs = CoordinateReferenceSystem::jsonUnserialize($json);
 
-        $expectedProperties = array(
+        $expectedProperties = [
             'href' => 'https://example.com/crs/42',
             'type' => 'proj4',
-        );
+        ];
 
         $this->assertInstanceOf(Linked::class, $crs);
         $this->assertSame('link', $crs->getType());
@@ -78,7 +83,7 @@ JSON;
      * @dataProvider provideJsonDecodeAssocOptions
      * @group functional
      */
-    public function testUnserializationWithoutHrefType($assoc)
+    public function testUnserializationWithoutHrefType($assoc): void
     {
         $json = <<<'JSON'
 {
@@ -92,7 +97,7 @@ JSON;
         $json = json_decode($json, $assoc);
         $crs = CoordinateReferenceSystem::jsonUnserialize($json);
 
-        $expectedProperties = array('href' => 'https://example.com/crs/42');
+        $expectedProperties = ['href' => 'https://example.com/crs/42'];
 
         $this->assertInstanceOf(Linked::class, $crs);
         $this->assertSame('link', $crs->getType());
@@ -101,25 +106,25 @@ JSON;
 
     public function provideJsonDecodeAssocOptions()
     {
-        return array(
-            'assoc=true' => array(true),
-            'assoc=false' => array(false),
-        );
+        return [
+            'assoc=true' => [true],
+            'assoc=false' => [false],
+        ];
     }
 
-    public function testUnserializationShouldRequirePropertiesArrayOrObject()
+    public function testUnserializationShouldRequirePropertiesArrayOrObject(): void
     {
         $this->expectException(UnserializationException::class);
         $this->expectExceptionMessage('Linked CRS expected "properties" property of type array or object');
 
-        CoordinateReferenceSystem::jsonUnserialize(array('type' => 'link', 'properties' => null));
+        CoordinateReferenceSystem::jsonUnserialize(['type' => 'link', 'properties' => null]);
     }
 
-    public function testUnserializationShouldRequireHrefProperty()
+    public function testUnserializationShouldRequireHrefProperty(): void
     {
         $this->expectException(UnserializationException::class);
         $this->expectExceptionMessage('Linked CRS expected "properties.href" property of type string');
 
-        CoordinateReferenceSystem::jsonUnserialize(array('type' => 'link', 'properties' => array()));
+        CoordinateReferenceSystem::jsonUnserialize(['type' => 'link', 'properties' => []]);
     }
 }

--- a/tests/GeoJson/Tests/CoordinateReferenceSystem/NamedTest.php
+++ b/tests/GeoJson/Tests/CoordinateReferenceSystem/NamedTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Tests\CoordinateReferenceSystem;
 
 use GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem;
@@ -7,23 +9,26 @@ use GeoJson\CoordinateReferenceSystem\Named;
 use GeoJson\Exception\UnserializationException;
 use PHPUnit\Framework\TestCase;
 
+use function is_subclass_of;
+use function json_decode;
+
 class NamedTest extends TestCase
 {
-    public function testIsSubclassOfCoordinateReferenceSystem()
+    public function testIsSubclassOfCoordinateReferenceSystem(): void
     {
         $this->assertTrue(is_subclass_of(Named::class, CoordinateReferenceSystem::class));
     }
 
-    public function testSerialization()
+    public function testSerialization(): void
     {
         $crs = new Named('urn:ogc:def:crs:OGC:1.3:CRS84');
 
-        $expected = array(
+        $expected = [
             'type' => 'name',
-            'properties' => array(
+            'properties' => [
                 'name' => 'urn:ogc:def:crs:OGC:1.3:CRS84'
-            ),
-        );
+            ],
+        ];
 
         $this->assertSame('name', $crs->getType());
         $this->assertSame($expected['properties'], $crs->getProperties());
@@ -34,7 +39,7 @@ class NamedTest extends TestCase
      * @dataProvider provideJsonDecodeAssocOptions
      * @group functional
      */
-    public function testUnserialization($assoc)
+    public function testUnserialization($assoc): void
     {
         $json = <<<'JSON'
 {
@@ -48,7 +53,7 @@ JSON;
         $json = json_decode($json, $assoc);
         $crs = CoordinateReferenceSystem::jsonUnserialize($json);
 
-        $expectedProperties = array('name' => 'urn:ogc:def:crs:OGC:1.3:CRS84');
+        $expectedProperties = ['name' => 'urn:ogc:def:crs:OGC:1.3:CRS84'];
 
         $this->assertInstanceOf(Named::class, $crs);
         $this->assertSame('name', $crs->getType());
@@ -57,25 +62,25 @@ JSON;
 
     public function provideJsonDecodeAssocOptions()
     {
-        return array(
-            'assoc=true' => array(true),
-            'assoc=false' => array(false),
-        );
+        return [
+            'assoc=true' => [true],
+            'assoc=false' => [false],
+        ];
     }
 
-    public function testUnserializationShouldRequirePropertiesArrayOrObject()
+    public function testUnserializationShouldRequirePropertiesArrayOrObject(): void
     {
         $this->expectException(UnserializationException::class);
         $this->expectExceptionMessage('Named CRS expected "properties" property of type array or object');
 
-        CoordinateReferenceSystem::jsonUnserialize(array('type' => 'name', 'properties' => null));
+        CoordinateReferenceSystem::jsonUnserialize(['type' => 'name', 'properties' => null]);
     }
 
-    public function testUnserializationShouldRequireNameProperty()
+    public function testUnserializationShouldRequireNameProperty(): void
     {
         $this->expectException(UnserializationException::class);
         $this->expectExceptionMessage('Named CRS expected "properties.name" property of type string');
 
-        CoordinateReferenceSystem::jsonUnserialize(array('type' => 'name', 'properties' => array()));
+        CoordinateReferenceSystem::jsonUnserialize(['type' => 'name', 'properties' => []]);
     }
 }

--- a/tests/GeoJson/Tests/CoordinateReferenceSystem/NamedTest.php
+++ b/tests/GeoJson/Tests/CoordinateReferenceSystem/NamedTest.php
@@ -11,10 +11,7 @@ class NamedTest extends TestCase
 {
     public function testIsSubclassOfCoordinateReferenceSystem()
     {
-        $this->assertTrue(is_subclass_of(
-            'GeoJson\CoordinateReferenceSystem\Named',
-            'GeoJson\CoordinateReferenceSystem\CoordinateReferenceSystem'
-        ));
+        $this->assertTrue(is_subclass_of(Named::class, CoordinateReferenceSystem::class));
     }
 
     public function testSerialization()
@@ -53,7 +50,7 @@ JSON;
 
         $expectedProperties = array('name' => 'urn:ogc:def:crs:OGC:1.3:CRS84');
 
-        $this->assertInstanceOf('GeoJson\CoordinateReferenceSystem\Named', $crs);
+        $this->assertInstanceOf(Named::class, $crs);
         $this->assertSame('name', $crs->getType());
         $this->assertSame($expectedProperties, $crs->getProperties());
     }

--- a/tests/GeoJson/Tests/Feature/FeatureCollectionTest.php
+++ b/tests/GeoJson/Tests/Feature/FeatureCollectionTest.php
@@ -3,22 +3,19 @@
 namespace GeoJson\Tests\Feature;
 
 use GeoJson\Exception\UnserializationException;
+use GeoJson\Feature\Feature;
 use GeoJson\Feature\FeatureCollection;
 use GeoJson\GeoJson;
+use GeoJson\Geometry\Point;
 use GeoJson\Tests\BaseGeoJsonTest;
 use InvalidArgumentException;
-use GeoJson\Feature\Feature;
-use GeoJson\Geometry\Point;
-use ReflectionClass;
 use stdClass;
 
 class FeatureCollectionTest extends BaseGeoJsonTest
 {
-    public function createSubjectWithExtraArguments(array $extraArgs)
+    public function createSubjectWithExtraArguments(... $extraArgs)
     {
-        $class = new ReflectionClass(FeatureCollection::class);
-
-        return $class->newInstanceArgs(array_merge(array(array()), $extraArgs));
+        return new FeatureCollection([], ... $extraArgs);
     }
 
     public function testIsSubclassOfGeoJson()

--- a/tests/GeoJson/Tests/Feature/FeatureCollectionTest.php
+++ b/tests/GeoJson/Tests/Feature/FeatureCollectionTest.php
@@ -83,13 +83,8 @@ class FeatureCollectionTest extends BaseGeoJsonTest
             $this->getMockFeature(),
         );
 
-        $features[0]->expects($this->any())
-            ->method('jsonSerialize')
-            ->will($this->returnValue(['feature1']));
-
-        $features[1]->expects($this->any())
-            ->method('jsonSerialize')
-            ->will($this->returnValue(['feature2']));
+        $features[0]->method('jsonSerialize')->willReturn(['feature1']);
+        $features[1]->method('jsonSerialize')->willReturn(['feature2']);
 
         $collection = new FeatureCollection($features);
 

--- a/tests/GeoJson/Tests/Feature/FeatureCollectionTest.php
+++ b/tests/GeoJson/Tests/Feature/FeatureCollectionTest.php
@@ -9,12 +9,14 @@ use GeoJson\Tests\BaseGeoJsonTest;
 use InvalidArgumentException;
 use GeoJson\Feature\Feature;
 use GeoJson\Geometry\Point;
+use ReflectionClass;
+use stdClass;
 
 class FeatureCollectionTest extends BaseGeoJsonTest
 {
     public function createSubjectWithExtraArguments(array $extraArgs)
     {
-        $class = new \ReflectionClass(FeatureCollection::class);
+        $class = new ReflectionClass(FeatureCollection::class);
 
         return $class->newInstanceArgs(array_merge(array(array()), $extraArgs));
     }
@@ -30,7 +32,7 @@ class FeatureCollectionTest extends BaseGeoJsonTest
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('FeatureCollection may only contain Feature objects');
 
-        new FeatureCollection(array(new \stdClass()));
+        new FeatureCollection(array(new stdClass()));
     }
 
     public function testConstructorShouldReindexFeaturesArrayNumerically()

--- a/tests/GeoJson/Tests/Feature/FeatureCollectionTest.php
+++ b/tests/GeoJson/Tests/Feature/FeatureCollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Tests\Feature;
 
 use GeoJson\Exception\UnserializationException;
@@ -11,48 +13,52 @@ use GeoJson\Tests\BaseGeoJsonTest;
 use InvalidArgumentException;
 use stdClass;
 
+use function is_subclass_of;
+use function iterator_to_array;
+use function json_decode;
+
 class FeatureCollectionTest extends BaseGeoJsonTest
 {
-    public function createSubjectWithExtraArguments(... $extraArgs)
+    public function createSubjectWithExtraArguments(...$extraArgs)
     {
         return new FeatureCollection([], ... $extraArgs);
     }
 
-    public function testIsSubclassOfGeoJson()
+    public function testIsSubclassOfGeoJson(): void
     {
         $this->assertTrue(is_subclass_of(FeatureCollection::class, GeoJson::class));
     }
 
 
-    public function testConstructorShouldRequireArrayOfFeatureObjects()
+    public function testConstructorShouldRequireArrayOfFeatureObjects(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('FeatureCollection may only contain Feature objects');
 
-        new FeatureCollection(array(new stdClass()));
+        new FeatureCollection([new stdClass()]);
     }
 
-    public function testConstructorShouldReindexFeaturesArrayNumerically()
+    public function testConstructorShouldReindexFeaturesArrayNumerically(): void
     {
         $feature1 = $this->getMockFeature();
         $feature2 = $this->getMockFeature();
 
-        $features = array(
+        $features = [
             'one' => $feature1,
             'two' => $feature2,
-        );
+        ];
 
         $collection = new FeatureCollection($features);
 
-        $this->assertSame(array($feature1, $feature2), iterator_to_array($collection));
+        $this->assertSame([$feature1, $feature2], iterator_to_array($collection));
     }
 
-    public function testIsTraversable()
+    public function testIsTraversable(): void
     {
-        $features = array(
+        $features = [
             $this->getMockFeature(),
             $this->getMockFeature(),
-        );
+        ];
 
         $collection = new FeatureCollection($features);
 
@@ -60,12 +66,12 @@ class FeatureCollectionTest extends BaseGeoJsonTest
         $this->assertSame($features, iterator_to_array($collection));
     }
 
-    public function testIsCountable()
+    public function testIsCountable(): void
     {
-        $features = array(
+        $features = [
             $this->getMockFeature(),
             $this->getMockFeature(),
-        );
+        ];
 
         $collection = new FeatureCollection($features);
 
@@ -73,22 +79,22 @@ class FeatureCollectionTest extends BaseGeoJsonTest
         $this->assertCount(2, $collection);
     }
 
-    public function testSerialization()
+    public function testSerialization(): void
     {
-        $features = array(
+        $features = [
             $this->getMockFeature(),
             $this->getMockFeature(),
-        );
+        ];
 
         $features[0]->method('jsonSerialize')->willReturn(['feature1']);
         $features[1]->method('jsonSerialize')->willReturn(['feature2']);
 
         $collection = new FeatureCollection($features);
 
-        $expected = array(
+        $expected = [
             'type' => 'FeatureCollection',
-            'features' => array(['feature1'], ['feature2']),
-        );
+            'features' => [['feature1'], ['feature2']],
+        ];
 
         $this->assertSame('FeatureCollection', $collection->getType());
         $this->assertSame($features, $collection->getFeatures());
@@ -99,7 +105,7 @@ class FeatureCollectionTest extends BaseGeoJsonTest
      * @dataProvider provideJsonDecodeAssocOptions
      * @group functional
      */
-    public function testUnserialization($assoc)
+    public function testUnserialization($assoc): void
     {
         $json = <<<'JSON'
 {
@@ -136,30 +142,30 @@ JSON;
 
         $this->assertInstanceOf(Point::class, $geometry);
         $this->assertSame('Point', $geometry->getType());
-        $this->assertSame(array(1, 1), $geometry->getCoordinates());
+        $this->assertSame([1, 1], $geometry->getCoordinates());
     }
 
     public function provideJsonDecodeAssocOptions()
     {
-        return array(
-            'assoc=true' => array(true),
-            'assoc=false' => array(false),
-        );
+        return [
+            'assoc=true' => [true],
+            'assoc=false' => [false],
+        ];
     }
 
-    public function testUnserializationShouldRequireFeaturesProperty()
+    public function testUnserializationShouldRequireFeaturesProperty(): void
     {
         $this->expectException(UnserializationException::class);
         $this->expectExceptionMessage('FeatureCollection expected "features" property of type array, none given');
 
-        GeoJson::jsonUnserialize(array('type' => 'FeatureCollection'));
+        GeoJson::jsonUnserialize(['type' => 'FeatureCollection']);
     }
 
-    public function testUnserializationShouldRequireFeaturesArray()
+    public function testUnserializationShouldRequireFeaturesArray(): void
     {
         $this->expectException(UnserializationException::class);
         $this->expectExceptionMessage('FeatureCollection expected "features" property of type array');
 
-        GeoJson::jsonUnserialize(array('type' => 'FeatureCollection', 'features' => null));
+        GeoJson::jsonUnserialize(['type' => 'FeatureCollection', 'features' => null]);
     }
 }

--- a/tests/GeoJson/Tests/Feature/FeatureCollectionTest.php
+++ b/tests/GeoJson/Tests/Feature/FeatureCollectionTest.php
@@ -7,19 +7,21 @@ use GeoJson\Feature\FeatureCollection;
 use GeoJson\GeoJson;
 use GeoJson\Tests\BaseGeoJsonTest;
 use InvalidArgumentException;
+use GeoJson\Feature\Feature;
+use GeoJson\Geometry\Point;
 
 class FeatureCollectionTest extends BaseGeoJsonTest
 {
     public function createSubjectWithExtraArguments(array $extraArgs)
     {
-        $class = new \ReflectionClass('GeoJson\Feature\FeatureCollection');
+        $class = new \ReflectionClass(FeatureCollection::class);
 
         return $class->newInstanceArgs(array_merge(array(array()), $extraArgs));
     }
 
     public function testIsSubclassOfGeoJson()
     {
-        $this->assertTrue(is_subclass_of('GeoJson\Feature\FeatureCollection', 'GeoJson\GeoJson'));
+        $this->assertTrue(is_subclass_of(FeatureCollection::class, GeoJson::class));
     }
 
 
@@ -124,21 +126,21 @@ JSON;
         $json = json_decode($json, $assoc);
         $collection = GeoJson::jsonUnserialize($json);
 
-        $this->assertInstanceOf('GeoJson\Feature\FeatureCollection', $collection);
+        $this->assertInstanceOf(FeatureCollection::class, $collection);
         $this->assertSame('FeatureCollection', $collection->getType());
         $this->assertCount(1, $collection);
 
         $features = iterator_to_array($collection);
         $feature = $features[0];
 
-        $this->assertInstanceOf('GeoJson\Feature\Feature', $feature);
+        $this->assertInstanceOf(Feature::class, $feature);
         $this->assertSame('Feature', $feature->getType());
         $this->assertSame('test.feature.1', $feature->getId());
         $this->assertNull($feature->getProperties());
 
         $geometry = $feature->getGeometry();
 
-        $this->assertInstanceOf('GeoJson\Geometry\Point', $geometry);
+        $this->assertInstanceOf(Point::class, $geometry);
         $this->assertSame('Point', $geometry->getType());
         $this->assertSame(array(1, 1), $geometry->getCoordinates());
     }

--- a/tests/GeoJson/Tests/Feature/FeatureTest.php
+++ b/tests/GeoJson/Tests/Feature/FeatureTest.php
@@ -5,19 +5,20 @@ namespace GeoJson\Tests\Feature;
 use GeoJson\Feature\Feature;
 use GeoJson\GeoJson;
 use GeoJson\Tests\BaseGeoJsonTest;
+use GeoJson\Geometry\Point;
 
 class FeatureTest extends BaseGeoJsonTest
 {
     public function createSubjectWithExtraArguments(array $extraArgs)
     {
-        $class = new \ReflectionClass('GeoJson\Feature\Feature');
+        $class = new \ReflectionClass(Feature::class);
 
         return $class->newInstanceArgs(array_merge(array(null, null, null), $extraArgs));
     }
 
     public function testIsSubclassOfGeoJson()
     {
-        $this->assertTrue(is_subclass_of('GeoJson\Feature\Feature', 'GeoJson\GeoJson'));
+        $this->assertTrue(is_subclass_of(Feature::class, GeoJson::class));
     }
 
     public function testSerialization()
@@ -96,14 +97,14 @@ JSON;
         $json = json_decode($json, $assoc);
         $feature = GeoJson::jsonUnserialize($json);
 
-        $this->assertInstanceOf('GeoJson\Feature\Feature', $feature);
+        $this->assertInstanceOf(Feature::class, $feature);
         $this->assertSame('Feature', $feature->getType());
         $this->assertSame('test.feature.1', $feature->getId());
         $this->assertSame(array('key' => 'value'), $feature->getProperties());
 
         $geometry = $feature->getGeometry();
 
-        $this->assertInstanceOf('GeoJson\Geometry\Point', $geometry);
+        $this->assertInstanceOf(Point::class, $geometry);
         $this->assertSame('Point', $geometry->getType());
         $this->assertSame(array(1, 1), $geometry->getCoordinates());
     }

--- a/tests/GeoJson/Tests/Feature/FeatureTest.php
+++ b/tests/GeoJson/Tests/Feature/FeatureTest.php
@@ -27,9 +27,7 @@ class FeatureTest extends BaseGeoJsonTest
     {
         $geometry = $this->getMockGeometry();
 
-        $geometry->expects($this->any())
-            ->method('jsonSerialize')
-            ->will($this->returnValue(['geometry']));
+        $geometry->method('jsonSerialize')->willReturn(['geometry']);
 
         $properties = array('key' => 'value');
         $id = 'identifier';

--- a/tests/GeoJson/Tests/Feature/FeatureTest.php
+++ b/tests/GeoJson/Tests/Feature/FeatureTest.php
@@ -4,18 +4,15 @@ namespace GeoJson\Tests\Feature;
 
 use GeoJson\Feature\Feature;
 use GeoJson\GeoJson;
-use GeoJson\Tests\BaseGeoJsonTest;
 use GeoJson\Geometry\Point;
-use ReflectionClass;
+use GeoJson\Tests\BaseGeoJsonTest;
 use stdClass;
 
 class FeatureTest extends BaseGeoJsonTest
 {
-    public function createSubjectWithExtraArguments(array $extraArgs)
+    public function createSubjectWithExtraArguments(... $extraArgs)
     {
-        $class = new ReflectionClass(Feature::class);
-
-        return $class->newInstanceArgs(array_merge(array(null, null, null), $extraArgs));
+        return new Feature(null, null, null, ... $extraArgs);
     }
 
     public function testIsSubclassOfGeoJson()

--- a/tests/GeoJson/Tests/Feature/FeatureTest.php
+++ b/tests/GeoJson/Tests/Feature/FeatureTest.php
@@ -6,12 +6,14 @@ use GeoJson\Feature\Feature;
 use GeoJson\GeoJson;
 use GeoJson\Tests\BaseGeoJsonTest;
 use GeoJson\Geometry\Point;
+use ReflectionClass;
+use stdClass;
 
 class FeatureTest extends BaseGeoJsonTest
 {
     public function createSubjectWithExtraArguments(array $extraArgs)
     {
-        $class = new \ReflectionClass(Feature::class);
+        $class = new ReflectionClass(Feature::class);
 
         return $class->newInstanceArgs(array_merge(array(null, null, null), $extraArgs));
     }
@@ -68,7 +70,7 @@ class FeatureTest extends BaseGeoJsonTest
         $expected = array(
             'type' => 'Feature',
             'geometry' => null,
-            'properties' => new \stdClass(),
+            'properties' => new stdClass(),
         );
 
         $this->assertEquals($expected, $feature->jsonSerialize());

--- a/tests/GeoJson/Tests/Feature/FeatureTest.php
+++ b/tests/GeoJson/Tests/Feature/FeatureTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Tests\Feature;
 
 use GeoJson\Feature\Feature;
@@ -8,35 +10,38 @@ use GeoJson\Geometry\Point;
 use GeoJson\Tests\BaseGeoJsonTest;
 use stdClass;
 
+use function is_subclass_of;
+use function json_decode;
+
 class FeatureTest extends BaseGeoJsonTest
 {
-    public function createSubjectWithExtraArguments(... $extraArgs)
+    public function createSubjectWithExtraArguments(...$extraArgs)
     {
         return new Feature(null, null, null, ... $extraArgs);
     }
 
-    public function testIsSubclassOfGeoJson()
+    public function testIsSubclassOfGeoJson(): void
     {
         $this->assertTrue(is_subclass_of(Feature::class, GeoJson::class));
     }
 
-    public function testSerialization()
+    public function testSerialization(): void
     {
         $geometry = $this->getMockGeometry();
 
         $geometry->method('jsonSerialize')->willReturn(['geometry']);
 
-        $properties = array('key' => 'value');
+        $properties = ['key' => 'value'];
         $id = 'identifier';
 
         $feature = new Feature($geometry, $properties, $id);
 
-        $expected = array(
+        $expected = [
             'type' => 'Feature',
             'geometry' => ['geometry'],
             'properties' => $properties,
             'id' => 'identifier',
-        );
+        ];
 
         $this->assertSame('Feature', $feature->getType());
         $this->assertSame($geometry, $feature->getGeometry());
@@ -45,28 +50,28 @@ class FeatureTest extends BaseGeoJsonTest
         $this->assertSame($expected, $feature->jsonSerialize());
     }
 
-    public function testSerializationWithNullConstructorArguments()
+    public function testSerializationWithNullConstructorArguments(): void
     {
         $feature = new Feature();
 
-        $expected = array(
+        $expected = [
             'type' => 'Feature',
             'geometry' => null,
             'properties' => null,
-        );
+        ];
 
         $this->assertSame($expected, $feature->jsonSerialize());
     }
 
-    public function testSerializationShouldConvertEmptyPropertiesArrayToObject()
+    public function testSerializationShouldConvertEmptyPropertiesArrayToObject(): void
     {
-        $feature = new Feature(null, array());
+        $feature = new Feature(null, []);
 
-        $expected = array(
+        $expected = [
             'type' => 'Feature',
             'geometry' => null,
             'properties' => new stdClass(),
-        );
+        ];
 
         $this->assertEquals($expected, $feature->jsonSerialize());
     }
@@ -75,7 +80,7 @@ class FeatureTest extends BaseGeoJsonTest
      * @dataProvider provideJsonDecodeAssocOptions
      * @group functional
      */
-    public function testUnserialization($assoc)
+    public function testUnserialization($assoc): void
     {
         $json = <<<'JSON'
 {
@@ -97,20 +102,20 @@ JSON;
         $this->assertInstanceOf(Feature::class, $feature);
         $this->assertSame('Feature', $feature->getType());
         $this->assertSame('test.feature.1', $feature->getId());
-        $this->assertSame(array('key' => 'value'), $feature->getProperties());
+        $this->assertSame(['key' => 'value'], $feature->getProperties());
 
         $geometry = $feature->getGeometry();
 
         $this->assertInstanceOf(Point::class, $geometry);
         $this->assertSame('Point', $geometry->getType());
-        $this->assertSame(array(1, 1), $geometry->getCoordinates());
+        $this->assertSame([1, 1], $geometry->getCoordinates());
     }
 
     public function provideJsonDecodeAssocOptions()
     {
-        return array(
-            'assoc=true' => array(true),
-            'assoc=false' => array(false),
-        );
+        return [
+            'assoc=true' => [true],
+            'assoc=false' => [false],
+        ];
     }
 }

--- a/tests/GeoJson/Tests/GeoJsonTest.php
+++ b/tests/GeoJson/Tests/GeoJsonTest.php
@@ -3,18 +3,23 @@
 namespace GeoJson\Tests;
 
 use GeoJson\GeoJson;
+use GeoJson\JsonUnserializable;
+use JsonSerializable;
 use PHPUnit\Framework\TestCase;
+use GeoJson\Geometry\Point;
+use GeoJson\BoundingBox;
+use GeoJson\CoordinateReferenceSystem\Named;
 
 class GeoJsonTest extends TestCase
 {
     public function testIsJsonSerializable()
     {
-        $this->assertInstanceOf('JsonSerializable', $this->createMock('GeoJson\GeoJson'));
+        $this->assertInstanceOf(JsonSerializable::class, $this->createMock(GeoJson::class));
     }
 
     public function testIsJsonUnserializable()
     {
-        $this->assertInstanceOf('GeoJson\JsonUnserializable', $this->createMock('GeoJson\GeoJson'));
+        $this->assertInstanceOf(JsonUnserializable::class, $this->createMock(GeoJson::class));
     }
 
     /**
@@ -34,13 +39,13 @@ JSON;
         $json = json_decode($json, $assoc);
         $point = GeoJson::jsonUnserialize($json);
 
-        $this->assertInstanceOf('GeoJson\Geometry\Point', $point);
+        $this->assertInstanceOf(Point::class, $point);
         $this->assertSame('Point', $point->getType());
         $this->assertSame(array(1, 1), $point->getCoordinates());
 
         $boundingBox = $point->getBoundingBox();
 
-        $this->assertInstanceOf('GeoJson\BoundingBox', $boundingBox);
+        $this->assertInstanceOf(BoundingBox::class, $boundingBox);
         $this->assertSame(array(-180.0, -90.0, 180.0, 90.0), $boundingBox->getBounds());
     }
 
@@ -66,7 +71,7 @@ JSON;
         $json = json_decode($json, $assoc);
         $point = GeoJson::jsonUnserialize($json);
 
-        $this->assertInstanceOf('GeoJson\Geometry\Point', $point);
+        $this->assertInstanceOf(Point::class, $point);
         $this->assertSame('Point', $point->getType());
         $this->assertSame(array(1, 1), $point->getCoordinates());
 
@@ -74,7 +79,7 @@ JSON;
 
         $expectedProperties = array('name' => 'urn:ogc:def:crs:OGC:1.3:CRS84');
 
-        $this->assertInstanceOf('GeoJson\CoordinateReferenceSystem\Named', $crs);
+        $this->assertInstanceOf(Named::class, $crs);
         $this->assertSame('name', $crs->getType());
         $this->assertSame($expectedProperties, $crs->getProperties());
     }

--- a/tests/GeoJson/Tests/GeoJsonTest.php
+++ b/tests/GeoJson/Tests/GeoJsonTest.php
@@ -2,13 +2,14 @@
 
 namespace GeoJson\Tests;
 
+use GeoJson\BoundingBox;
+use GeoJson\CoordinateReferenceSystem\Named;
+use GeoJson\Exception\UnserializationException;
 use GeoJson\GeoJson;
+use GeoJson\Geometry\Point;
 use GeoJson\JsonUnserializable;
 use JsonSerializable;
 use PHPUnit\Framework\TestCase;
-use GeoJson\Geometry\Point;
-use GeoJson\BoundingBox;
-use GeoJson\CoordinateReferenceSystem\Named;
 
 class GeoJsonTest extends TestCase
 {

--- a/tests/GeoJson/Tests/GeoJsonTest.php
+++ b/tests/GeoJson/Tests/GeoJsonTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Tests;
 
 use GeoJson\BoundingBox;
@@ -11,14 +13,19 @@ use GeoJson\JsonUnserializable;
 use JsonSerializable;
 use PHPUnit\Framework\TestCase;
 
+use function json_decode;
+use function is_object;
+use function get_class;
+use function gettype;
+
 class GeoJsonTest extends TestCase
 {
-    public function testIsJsonSerializable()
+    public function testIsJsonSerializable(): void
     {
         $this->assertInstanceOf(JsonSerializable::class, $this->createMock(GeoJson::class));
     }
 
-    public function testIsJsonUnserializable()
+    public function testIsJsonUnserializable(): void
     {
         $this->assertInstanceOf(JsonUnserializable::class, $this->createMock(GeoJson::class));
     }
@@ -27,7 +34,7 @@ class GeoJsonTest extends TestCase
      * @dataProvider provideJsonDecodeAssocOptions
      * @group functional
      */
-    public function testUnserializationWithBoundingBox($assoc)
+    public function testUnserializationWithBoundingBox($assoc): void
     {
         $json = <<<'JSON'
 {
@@ -42,19 +49,19 @@ JSON;
 
         $this->assertInstanceOf(Point::class, $point);
         $this->assertSame('Point', $point->getType());
-        $this->assertSame(array(1, 1), $point->getCoordinates());
+        $this->assertSame([1, 1], $point->getCoordinates());
 
         $boundingBox = $point->getBoundingBox();
 
         $this->assertInstanceOf(BoundingBox::class, $boundingBox);
-        $this->assertSame(array(-180.0, -90.0, 180.0, 90.0), $boundingBox->getBounds());
+        $this->assertSame([-180.0, -90.0, 180.0, 90.0], $boundingBox->getBounds());
     }
 
     /**
      * @dataProvider provideJsonDecodeAssocOptions
      * @group functional
      */
-    public function testUnserializationWithCrs($assoc)
+    public function testUnserializationWithCrs($assoc): void
     {
         $json = <<<'JSON'
 {
@@ -74,18 +81,18 @@ JSON;
 
         $this->assertInstanceOf(Point::class, $point);
         $this->assertSame('Point', $point->getType());
-        $this->assertSame(array(1, 1), $point->getCoordinates());
+        $this->assertSame([1, 1], $point->getCoordinates());
 
         $crs = $point->getCrs();
 
-        $expectedProperties = array('name' => 'urn:ogc:def:crs:OGC:1.3:CRS84');
+        $expectedProperties = ['name' => 'urn:ogc:def:crs:OGC:1.3:CRS84'];
 
         $this->assertInstanceOf(Named::class, $crs);
         $this->assertSame('name', $crs->getType());
         $this->assertSame($expectedProperties, $crs->getProperties());
     }
 
-    public function testUnserializationWithInvalidArgument()
+    public function testUnserializationWithInvalidArgument(): void
     {
         $this->expectException(UnserializationException::class);
         $this->expectExceptionMessage('GeoJson expected value of type array or object, string given');
@@ -93,7 +100,7 @@ JSON;
         GeoJson::jsonUnserialize('must be array or object, but this is a string');
     }
 
-    public function testUnserializationWithUnknownType()
+    public function testUnserializationWithUnknownType(): void
     {
         $this->expectException(UnserializationException::class);
         $this->expectExceptionMessage('Invalid GeoJson type "Unknown"');
@@ -101,7 +108,7 @@ JSON;
         GeoJson::jsonUnserialize(['type' => 'Unknown']);
     }
 
-    public function testUnserializationWithMissingType()
+    public function testUnserializationWithMissingType(): void
     {
         $this->expectException(UnserializationException::class);
         $this->expectExceptionMessage('GeoJson expected "type" property of type string, none given');
@@ -112,7 +119,7 @@ JSON;
     /**
      * @dataProvider provideGeoJsonTypesWithCoordinates
      */
-    public function testUnserializationWithMissingCoordinates(string $type)
+    public function testUnserializationWithMissingCoordinates(string $type): void
     {
         $this->expectException(UnserializationException::class);
         $this->expectExceptionMessage($type . ' expected "coordinates" property of type array, none given');
@@ -127,12 +134,12 @@ JSON;
      *
      * @param mixed $value
      */
-    public function testUnserializationWithInvalidCoordinates($value)
+    public function testUnserializationWithInvalidCoordinates($value): void
     {
         $valueType = is_object($value) ? get_class($value) : gettype($value);
 
         $this->expectException(UnserializationException::class);
-        $this->expectExceptionMessage('Point expected "coordinates" property of type array, '.$valueType.' given');
+        $this->expectExceptionMessage('Point expected "coordinates" property of type array, ' . $valueType . ' given');
 
         GeoJson::jsonUnserialize([
             'type' => 'Point',
@@ -140,7 +147,7 @@ JSON;
         ]);
     }
 
-    public function testFeatureUnserializationWithInvalidGeometry()
+    public function testFeatureUnserializationWithInvalidGeometry(): void
     {
         $this->expectException(UnserializationException::class);
         $this->expectExceptionMessage('Feature expected "geometry" property of type array or object, string given');
@@ -151,7 +158,7 @@ JSON;
         ]);
     }
 
-    public function testFeatureUnserializationWithInvalidProperties()
+    public function testFeatureUnserializationWithInvalidProperties(): void
     {
         $this->expectException(UnserializationException::class);
         $this->expectExceptionMessage('Feature expected "properties" property of type array or object, string given');
@@ -164,19 +171,19 @@ JSON;
 
     public function provideJsonDecodeAssocOptions()
     {
-        return array(
-            'assoc=true' => array(true),
-            'assoc=false' => array(false),
-        );
+        return [
+            'assoc=true' => [true],
+            'assoc=false' => [false],
+        ];
     }
 
     public function provideGeoJsonTypesWithCoordinates()
     {
         return [
-            'LineString' =>['LineString'],
+            'LineString' => ['LineString'],
             'MultiLineString' => ['MultiLineString'],
             'MultiPoint' => ['MultiPoint'],
-            'MultiPolygon' =>['MultiPolygon'],
+            'MultiPolygon' => ['MultiPolygon'],
             'Point' => ['Point'],
             'Polygon' => ['Polygon'],
         ];

--- a/tests/GeoJson/Tests/Geometry/GeometryCollectionTest.php
+++ b/tests/GeoJson/Tests/Geometry/GeometryCollectionTest.php
@@ -9,12 +9,14 @@ use GeoJson\Tests\BaseGeoJsonTest;
 use InvalidArgumentException;
 use GeoJson\Geometry\Geometry;
 use GeoJson\Geometry\Point;
+use ReflectionClass;
+use stdClass;
 
 class GeometryCollectionTest extends BaseGeoJsonTest
 {
     public function createSubjectWithExtraArguments(array $extraArgs)
     {
-        $class = new \ReflectionClass(GeometryCollection::class);
+        $class = new ReflectionClass(GeometryCollection::class);
 
         return $class->newInstanceArgs(array_merge(array(array()), $extraArgs));
     }
@@ -29,7 +31,7 @@ class GeometryCollectionTest extends BaseGeoJsonTest
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('GeometryCollection may only contain Geometry objects');
 
-        new GeometryCollection(array(new \stdClass()));
+        new GeometryCollection(array(new stdClass()));
     }
 
     public function testConstructorShouldReindexGeometriesArrayNumerically()

--- a/tests/GeoJson/Tests/Geometry/GeometryCollectionTest.php
+++ b/tests/GeoJson/Tests/Geometry/GeometryCollectionTest.php
@@ -4,21 +4,18 @@ namespace GeoJson\Tests\Geometry;
 
 use GeoJson\Exception\UnserializationException;
 use GeoJson\GeoJson;
+use GeoJson\Geometry\Geometry;
 use GeoJson\Geometry\GeometryCollection;
+use GeoJson\Geometry\Point;
 use GeoJson\Tests\BaseGeoJsonTest;
 use InvalidArgumentException;
-use GeoJson\Geometry\Geometry;
-use GeoJson\Geometry\Point;
-use ReflectionClass;
 use stdClass;
 
 class GeometryCollectionTest extends BaseGeoJsonTest
 {
-    public function createSubjectWithExtraArguments(array $extraArgs)
+    public function createSubjectWithExtraArguments(... $extraArgs)
     {
-        $class = new ReflectionClass(GeometryCollection::class);
-
-        return $class->newInstanceArgs(array_merge(array(array()), $extraArgs));
+        return new GeometryCollection([], ... $extraArgs);
     }
 
     public function testIsSubclassOfGeometry()

--- a/tests/GeoJson/Tests/Geometry/GeometryCollectionTest.php
+++ b/tests/GeoJson/Tests/Geometry/GeometryCollectionTest.php
@@ -81,13 +81,8 @@ class GeometryCollectionTest extends BaseGeoJsonTest
             $this->getMockGeometry(),
         );
 
-        $geometries[0]->expects($this->any())
-            ->method('jsonSerialize')
-            ->will($this->returnValue(['geometry1']));
-
-        $geometries[1]->expects($this->any())
-            ->method('jsonSerialize')
-            ->will($this->returnValue(['geometry2']));
+        $geometries[0]->method('jsonSerialize')->willReturn(['geometry1']);
+        $geometries[1]->method('jsonSerialize')->willReturn(['geometry2']);
 
         $collection = new GeometryCollection($geometries);
 

--- a/tests/GeoJson/Tests/Geometry/GeometryCollectionTest.php
+++ b/tests/GeoJson/Tests/Geometry/GeometryCollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Tests\Geometry;
 
 use GeoJson\Exception\UnserializationException;
@@ -11,46 +13,50 @@ use GeoJson\Tests\BaseGeoJsonTest;
 use InvalidArgumentException;
 use stdClass;
 
+use function is_subclass_of;
+use function iterator_to_array;
+use function json_decode;
+
 class GeometryCollectionTest extends BaseGeoJsonTest
 {
-    public function createSubjectWithExtraArguments(... $extraArgs)
+    public function createSubjectWithExtraArguments(...$extraArgs)
     {
         return new GeometryCollection([], ... $extraArgs);
     }
 
-    public function testIsSubclassOfGeometry()
+    public function testIsSubclassOfGeometry(): void
     {
         $this->assertTrue(is_subclass_of(GeometryCollection::class, Geometry::class));
     }
 
-    public function testConstructorShouldRequireArrayOfGeometryObjects()
+    public function testConstructorShouldRequireArrayOfGeometryObjects(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('GeometryCollection may only contain Geometry objects');
 
-        new GeometryCollection(array(new stdClass()));
+        new GeometryCollection([new stdClass()]);
     }
 
-    public function testConstructorShouldReindexGeometriesArrayNumerically()
+    public function testConstructorShouldReindexGeometriesArrayNumerically(): void
     {
         $geometry1 = $this->getMockGeometry();
         $geometry2 = $this->getMockGeometry();
 
-        $geometries = array(
+        $geometries = [
             'one' => $geometry1,
             'two' => $geometry2,
-        );
+        ];
 
         $collection = new GeometryCollection($geometries);
-        $this->assertSame(array($geometry1, $geometry2), iterator_to_array($collection));
+        $this->assertSame([$geometry1, $geometry2], iterator_to_array($collection));
     }
 
-    public function testIsTraversable()
+    public function testIsTraversable(): void
     {
-        $geometries = array(
+        $geometries = [
             $this->getMockGeometry(),
             $this->getMockGeometry(),
-        );
+        ];
 
         $collection = new GeometryCollection($geometries);
 
@@ -58,12 +64,12 @@ class GeometryCollectionTest extends BaseGeoJsonTest
         $this->assertSame($geometries, iterator_to_array($collection));
     }
 
-    public function testIsCountable()
+    public function testIsCountable(): void
     {
-        $geometries = array(
+        $geometries = [
             $this->getMockGeometry(),
             $this->getMockGeometry(),
-        );
+        ];
 
         $collection = new GeometryCollection($geometries);
 
@@ -71,22 +77,22 @@ class GeometryCollectionTest extends BaseGeoJsonTest
         $this->assertCount(2, $collection);
     }
 
-    public function testSerialization()
+    public function testSerialization(): void
     {
-        $geometries = array(
+        $geometries = [
             $this->getMockGeometry(),
             $this->getMockGeometry(),
-        );
+        ];
 
         $geometries[0]->method('jsonSerialize')->willReturn(['geometry1']);
         $geometries[1]->method('jsonSerialize')->willReturn(['geometry2']);
 
         $collection = new GeometryCollection($geometries);
 
-        $expected = array(
+        $expected = [
             'type' => 'GeometryCollection',
-            'geometries' => array(['geometry1'], ['geometry2']),
-        );
+            'geometries' => [['geometry1'], ['geometry2']],
+        ];
 
         $this->assertSame('GeometryCollection', $collection->getType());
         $this->assertSame($geometries, $collection->getGeometries());
@@ -97,7 +103,7 @@ class GeometryCollectionTest extends BaseGeoJsonTest
      * @dataProvider provideJsonDecodeAssocOptions
      * @group functional
      */
-    public function testUnserialization($assoc)
+    public function testUnserialization($assoc): void
     {
         $json = <<<'JSON'
 {
@@ -123,30 +129,30 @@ JSON;
 
         $this->assertInstanceOf(Point::class, $geometry);
         $this->assertSame('Point', $geometry->getType());
-        $this->assertSame(array(1, 1), $geometry->getCoordinates());
+        $this->assertSame([1, 1], $geometry->getCoordinates());
     }
 
     public function provideJsonDecodeAssocOptions()
     {
-        return array(
-            'assoc=true' => array(true),
-            'assoc=false' => array(false),
-        );
+        return [
+            'assoc=true' => [true],
+            'assoc=false' => [false],
+        ];
     }
 
-    public function testUnserializationShouldRequireGeometriesProperty()
+    public function testUnserializationShouldRequireGeometriesProperty(): void
     {
         $this->expectException(UnserializationException::class);
         $this->expectExceptionMessage('GeometryCollection expected "geometries" property of type array, none given');
 
-        GeoJson::jsonUnserialize(array('type' => 'GeometryCollection'));
+        GeoJson::jsonUnserialize(['type' => 'GeometryCollection']);
     }
 
-    public function testUnserializationShouldRequireGeometriesArray()
+    public function testUnserializationShouldRequireGeometriesArray(): void
     {
         $this->expectException(UnserializationException::class);
         $this->expectExceptionMessage('GeometryCollection expected "geometries" property of type array');
 
-        GeoJson::jsonUnserialize(array('type' => 'GeometryCollection', 'geometries' => null));
+        GeoJson::jsonUnserialize(['type' => 'GeometryCollection', 'geometries' => null]);
     }
 }

--- a/tests/GeoJson/Tests/Geometry/GeometryCollectionTest.php
+++ b/tests/GeoJson/Tests/Geometry/GeometryCollectionTest.php
@@ -7,19 +7,21 @@ use GeoJson\GeoJson;
 use GeoJson\Geometry\GeometryCollection;
 use GeoJson\Tests\BaseGeoJsonTest;
 use InvalidArgumentException;
+use GeoJson\Geometry\Geometry;
+use GeoJson\Geometry\Point;
 
 class GeometryCollectionTest extends BaseGeoJsonTest
 {
     public function createSubjectWithExtraArguments(array $extraArgs)
     {
-        $class = new \ReflectionClass('GeoJson\Geometry\GeometryCollection');
+        $class = new \ReflectionClass(GeometryCollection::class);
 
         return $class->newInstanceArgs(array_merge(array(array()), $extraArgs));
     }
 
     public function testIsSubclassOfGeometry()
     {
-        $this->assertTrue(is_subclass_of('GeoJson\Geometry\GeometryCollection', 'GeoJson\Geometry\Geometry'));
+        $this->assertTrue(is_subclass_of(GeometryCollection::class, Geometry::class));
     }
 
     public function testConstructorShouldRequireArrayOfGeometryObjects()
@@ -118,14 +120,14 @@ JSON;
         $json = json_decode($json, $assoc);
         $collection = GeoJson::jsonUnserialize($json);
 
-        $this->assertInstanceOf('GeoJson\Geometry\GeometryCollection', $collection);
+        $this->assertInstanceOf(GeometryCollection::class, $collection);
         $this->assertSame('GeometryCollection', $collection->getType());
         $this->assertCount(1, $collection);
 
         $geometries = iterator_to_array($collection);
         $geometry = $geometries[0];
 
-        $this->assertInstanceOf('GeoJson\Geometry\Point', $geometry);
+        $this->assertInstanceOf(Point::class, $geometry);
         $this->assertSame('Point', $geometry->getType());
         $this->assertSame(array(1, 1), $geometry->getCoordinates());
     }

--- a/tests/GeoJson/Tests/Geometry/GeometryTest.php
+++ b/tests/GeoJson/Tests/Geometry/GeometryTest.php
@@ -1,14 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Tests\Geometry;
 
 use GeoJson\GeoJson;
 use GeoJson\Geometry\Geometry;
 use PHPUnit\Framework\TestCase;
 
+use function is_subclass_of;
+
 class GeometryTest extends TestCase
 {
-    public function testIsSubclassOfGeoJson()
+    public function testIsSubclassOfGeoJson(): void
     {
         $this->assertTrue(is_subclass_of(Geometry::class, GeoJson::class));
     }

--- a/tests/GeoJson/Tests/Geometry/GeometryTest.php
+++ b/tests/GeoJson/Tests/Geometry/GeometryTest.php
@@ -2,9 +2,9 @@
 
 namespace GeoJson\Tests\Geometry;
 
-use PHPUnit\Framework\TestCase;
-use GeoJson\Geometry\Geometry;
 use GeoJson\GeoJson;
+use GeoJson\Geometry\Geometry;
+use PHPUnit\Framework\TestCase;
 
 class GeometryTest extends TestCase
 {

--- a/tests/GeoJson/Tests/Geometry/GeometryTest.php
+++ b/tests/GeoJson/Tests/Geometry/GeometryTest.php
@@ -3,11 +3,13 @@
 namespace GeoJson\Tests\Geometry;
 
 use PHPUnit\Framework\TestCase;
+use GeoJson\Geometry\Geometry;
+use GeoJson\GeoJson;
 
 class GeometryTest extends TestCase
 {
     public function testIsSubclassOfGeoJson()
     {
-        $this->assertTrue(is_subclass_of('GeoJson\Geometry\Geometry', 'GeoJson\GeoJson'));
+        $this->assertTrue(is_subclass_of(Geometry::class, GeoJson::class));
     }
 }

--- a/tests/GeoJson/Tests/Geometry/LineStringTest.php
+++ b/tests/GeoJson/Tests/Geometry/LineStringTest.php
@@ -7,12 +7,13 @@ use GeoJson\Geometry\LineString;
 use GeoJson\Tests\BaseGeoJsonTest;
 use InvalidArgumentException;
 use GeoJson\Geometry\MultiPoint;
+use ReflectionClass;
 
 class LineStringTest extends BaseGeoJsonTest
 {
     public function createSubjectWithExtraArguments(array $extraArgs)
     {
-        $class = new \ReflectionClass(LineString::class);
+        $class = new ReflectionClass(LineString::class);
 
         return $class->newInstanceArgs(array_merge(
             array(array(array(1, 1), array(2, 2))),

--- a/tests/GeoJson/Tests/Geometry/LineStringTest.php
+++ b/tests/GeoJson/Tests/Geometry/LineStringTest.php
@@ -6,12 +6,13 @@ use GeoJson\GeoJson;
 use GeoJson\Geometry\LineString;
 use GeoJson\Tests\BaseGeoJsonTest;
 use InvalidArgumentException;
+use GeoJson\Geometry\MultiPoint;
 
 class LineStringTest extends BaseGeoJsonTest
 {
     public function createSubjectWithExtraArguments(array $extraArgs)
     {
-        $class = new \ReflectionClass('GeoJson\Geometry\LineString');
+        $class = new \ReflectionClass(LineString::class);
 
         return $class->newInstanceArgs(array_merge(
             array(array(array(1, 1), array(2, 2))),
@@ -21,7 +22,7 @@ class LineStringTest extends BaseGeoJsonTest
 
     public function testIsSubclassOfMultiPoint()
     {
-        $this->assertTrue(is_subclass_of('GeoJson\Geometry\LineString', 'GeoJson\Geometry\MultiPoint'));
+        $this->assertTrue(is_subclass_of(LineString::class, MultiPoint::class));
     }
 
     public function testConstructorShouldRequireAtLeastTwoPositions()
@@ -68,7 +69,7 @@ JSON;
 
         $expectedCoordinates = array(array(1, 1), array(2, 2));
 
-        $this->assertInstanceOf('GeoJson\Geometry\LineString', $lineString);
+        $this->assertInstanceOf(LineString::class, $lineString);
         $this->assertSame('LineString', $lineString->getType());
         $this->assertSame($expectedCoordinates, $lineString->getCoordinates());
     }

--- a/tests/GeoJson/Tests/Geometry/LineStringTest.php
+++ b/tests/GeoJson/Tests/Geometry/LineStringTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Tests\Geometry;
 
 use GeoJson\GeoJson;
@@ -8,38 +10,41 @@ use GeoJson\Geometry\MultiPoint;
 use GeoJson\Tests\BaseGeoJsonTest;
 use InvalidArgumentException;
 
+use function is_subclass_of;
+use function json_decode;
+
 class LineStringTest extends BaseGeoJsonTest
 {
-    public function createSubjectWithExtraArguments(... $extraArgs)
+    public function createSubjectWithExtraArguments(...$extraArgs)
     {
         return new LineString(
-            array(array(1, 1), array(2, 2)),
+            [[1, 1], [2, 2]],
             ... $extraArgs
         );
     }
 
-    public function testIsSubclassOfMultiPoint()
+    public function testIsSubclassOfMultiPoint(): void
     {
         $this->assertTrue(is_subclass_of(LineString::class, MultiPoint::class));
     }
 
-    public function testConstructorShouldRequireAtLeastTwoPositions()
+    public function testConstructorShouldRequireAtLeastTwoPositions(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('LineString requires at least two positions');
 
-        new LineString(array(array(1, 1)));
+        new LineString([[1, 1]]);
     }
 
-    public function testSerialization()
+    public function testSerialization(): void
     {
-        $coordinates = array(array(1, 1), array(2, 2));
+        $coordinates = [[1, 1], [2, 2]];
         $lineString = new LineString($coordinates);
 
-        $expected = array(
+        $expected = [
             'type' => 'LineString',
             'coordinates' => $coordinates,
-        );
+        ];
 
         $this->assertSame('LineString', $lineString->getType());
         $this->assertSame($coordinates, $lineString->getCoordinates());
@@ -50,7 +55,7 @@ class LineStringTest extends BaseGeoJsonTest
      * @dataProvider provideJsonDecodeAssocOptions
      * @group functional
      */
-    public function testUnserialization($assoc)
+    public function testUnserialization($assoc): void
     {
         $json = <<<'JSON'
 {
@@ -65,7 +70,7 @@ JSON;
         $json = json_decode($json, $assoc);
         $lineString = GeoJson::jsonUnserialize($json);
 
-        $expectedCoordinates = array(array(1, 1), array(2, 2));
+        $expectedCoordinates = [[1, 1], [2, 2]];
 
         $this->assertInstanceOf(LineString::class, $lineString);
         $this->assertSame('LineString', $lineString->getType());
@@ -74,9 +79,9 @@ JSON;
 
     public function provideJsonDecodeAssocOptions()
     {
-        return array(
-            'assoc=true' => array(true),
-            'assoc=false' => array(false),
-        );
+        return [
+            'assoc=true' => [true],
+            'assoc=false' => [false],
+        ];
     }
 }

--- a/tests/GeoJson/Tests/Geometry/LineStringTest.php
+++ b/tests/GeoJson/Tests/Geometry/LineStringTest.php
@@ -4,21 +4,18 @@ namespace GeoJson\Tests\Geometry;
 
 use GeoJson\GeoJson;
 use GeoJson\Geometry\LineString;
+use GeoJson\Geometry\MultiPoint;
 use GeoJson\Tests\BaseGeoJsonTest;
 use InvalidArgumentException;
-use GeoJson\Geometry\MultiPoint;
-use ReflectionClass;
 
 class LineStringTest extends BaseGeoJsonTest
 {
-    public function createSubjectWithExtraArguments(array $extraArgs)
+    public function createSubjectWithExtraArguments(... $extraArgs)
     {
-        $class = new ReflectionClass(LineString::class);
-
-        return $class->newInstanceArgs(array_merge(
-            array(array(array(1, 1), array(2, 2))),
-            $extraArgs
-        ));
+        return new LineString(
+            array(array(1, 1), array(2, 2)),
+            ... $extraArgs
+        );
     }
 
     public function testIsSubclassOfMultiPoint()

--- a/tests/GeoJson/Tests/Geometry/LinearRingTest.php
+++ b/tests/GeoJson/Tests/Geometry/LinearRingTest.php
@@ -3,22 +3,19 @@
 namespace GeoJson\Tests\Geometry;
 
 use GeoJson\Geometry\LinearRing;
+use GeoJson\Geometry\LineString;
 use GeoJson\Geometry\Point;
 use GeoJson\Tests\BaseGeoJsonTest;
 use InvalidArgumentException;
-use GeoJson\Geometry\LineString;
-use ReflectionClass;
 
 class LinearRingTest extends BaseGeoJsonTest
 {
-    public function createSubjectWithExtraArguments(array $extraArgs)
+    public function createSubjectWithExtraArguments(... $extraArgs)
     {
-        $class = new ReflectionClass(LinearRing::class);
-
-        return $class->newInstanceArgs(array_merge(
-            array(array(array(1, 1), array(2, 2), array(3, 3), array(1, 1))),
-            $extraArgs
-        ));
+        return new LinearRing(
+            array(array(1, 1), array(2, 2), array(3, 3), array(1, 1)),
+            ... $extraArgs
+        );
     }
 
     public function testIsSubclassOfLineString()

--- a/tests/GeoJson/Tests/Geometry/LinearRingTest.php
+++ b/tests/GeoJson/Tests/Geometry/LinearRingTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Tests\Geometry;
 
 use GeoJson\Geometry\LinearRing;
@@ -8,68 +10,70 @@ use GeoJson\Geometry\Point;
 use GeoJson\Tests\BaseGeoJsonTest;
 use InvalidArgumentException;
 
+use function is_subclass_of;
+
 class LinearRingTest extends BaseGeoJsonTest
 {
-    public function createSubjectWithExtraArguments(... $extraArgs)
+    public function createSubjectWithExtraArguments(...$extraArgs)
     {
         return new LinearRing(
-            array(array(1, 1), array(2, 2), array(3, 3), array(1, 1)),
+            [[1, 1], [2, 2], [3, 3], [1, 1]],
             ... $extraArgs
         );
     }
 
-    public function testIsSubclassOfLineString()
+    public function testIsSubclassOfLineString(): void
     {
         $this->assertTrue(is_subclass_of(LinearRing::class, LineString::class));
     }
 
-    public function testConstructorShouldRequireAtLeastFourPositions()
+    public function testConstructorShouldRequireAtLeastFourPositions(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('LinearRing requires at least four positions');
 
-        new LinearRing(array(
-            array(1, 1),
-            array(2, 2),
-            array(3, 3),
-        ));
+        new LinearRing([
+            [1, 1],
+            [2, 2],
+            [3, 3],
+        ]);
     }
 
-    public function testConstructorShouldRequireEquivalentFirstAndLastPositions()
+    public function testConstructorShouldRequireEquivalentFirstAndLastPositions(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('LinearRing requires the first and last positions to be equivalent');
 
-        new LinearRing(array(
-            array(1, 1),
-            array(2, 2),
-            array(3, 3),
-            array(4, 4),
-        ));
+        new LinearRing([
+            [1, 1],
+            [2, 2],
+            [3, 3],
+            [4, 4],
+        ]);
     }
 
     /**
      * @doesNotPerformAssertions
      */
-    public function testConstructorShouldAcceptEquivalentPointObjectsAndPositionArrays()
+    public function testConstructorShouldAcceptEquivalentPointObjectsAndPositionArrays(): void
     {
-        new LinearRing(array(
-            array(1, 1),
-            array(2, 2),
-            array(3, 3),
-            new Point(array(1, 1)),
-        ));
+        new LinearRing([
+            [1, 1],
+            [2, 2],
+            [3, 3],
+            new Point([1, 1]),
+        ]);
     }
 
-    public function testSerialization()
+    public function testSerialization(): void
     {
-        $coordinates = array(array(1, 1), array(2, 2), array(3, 3), array(1, 1));
+        $coordinates = [[1, 1], [2, 2], [3, 3], [1, 1]];
         $linearRing = new LinearRing($coordinates);
 
-        $expected = array(
+        $expected = [
             'type' => 'LineString',
             'coordinates' => $coordinates,
-        );
+        ];
 
         $this->assertSame('LineString', $linearRing->getType());
         $this->assertSame($coordinates, $linearRing->getCoordinates());

--- a/tests/GeoJson/Tests/Geometry/LinearRingTest.php
+++ b/tests/GeoJson/Tests/Geometry/LinearRingTest.php
@@ -6,12 +6,13 @@ use GeoJson\Geometry\LinearRing;
 use GeoJson\Geometry\Point;
 use GeoJson\Tests\BaseGeoJsonTest;
 use InvalidArgumentException;
+use GeoJson\Geometry\LineString;
 
 class LinearRingTest extends BaseGeoJsonTest
 {
     public function createSubjectWithExtraArguments(array $extraArgs)
     {
-        $class = new \ReflectionClass('GeoJson\Geometry\LinearRing');
+        $class = new \ReflectionClass(LinearRing::class);
 
         return $class->newInstanceArgs(array_merge(
             array(array(array(1, 1), array(2, 2), array(3, 3), array(1, 1))),
@@ -21,7 +22,7 @@ class LinearRingTest extends BaseGeoJsonTest
 
     public function testIsSubclassOfLineString()
     {
-        $this->assertTrue(is_subclass_of('GeoJson\Geometry\LinearRing', 'GeoJson\Geometry\LineString'));
+        $this->assertTrue(is_subclass_of(LinearRing::class, LineString::class));
     }
 
     public function testConstructorShouldRequireAtLeastFourPositions()

--- a/tests/GeoJson/Tests/Geometry/LinearRingTest.php
+++ b/tests/GeoJson/Tests/Geometry/LinearRingTest.php
@@ -7,12 +7,13 @@ use GeoJson\Geometry\Point;
 use GeoJson\Tests\BaseGeoJsonTest;
 use InvalidArgumentException;
 use GeoJson\Geometry\LineString;
+use ReflectionClass;
 
 class LinearRingTest extends BaseGeoJsonTest
 {
     public function createSubjectWithExtraArguments(array $extraArgs)
     {
-        $class = new \ReflectionClass(LinearRing::class);
+        $class = new ReflectionClass(LinearRing::class);
 
         return $class->newInstanceArgs(array_merge(
             array(array(array(1, 1), array(2, 2), array(3, 3), array(1, 1))),

--- a/tests/GeoJson/Tests/Geometry/MultiLineStringTest.php
+++ b/tests/GeoJson/Tests/Geometry/MultiLineStringTest.php
@@ -3,25 +3,16 @@
 namespace GeoJson\Tests\Geometry;
 
 use GeoJson\GeoJson;
+use GeoJson\Geometry\Geometry;
 use GeoJson\Geometry\LineString;
 use GeoJson\Geometry\MultiLineString;
 use GeoJson\Tests\BaseGeoJsonTest;
-use GeoJson\Geometry\Geometry;
-use ReflectionClass;
 
 class MultiLineStringTest extends BaseGeoJsonTest
 {
-    public function createSubjectWithExtraArguments(array $extraArgs)
+    public function createSubjectWithExtraArguments(... $extraArgs)
     {
-        $class = new ReflectionClass(MultiLineString::class);
-
-        return $class->newInstanceArgs(array_merge(
-            array(array(
-                array(array(1, 1), array(2, 2)),
-                array(array(3, 3), array(4, 4)),
-            )),
-            $extraArgs
-        ));
+        return new MultiLineString([], ... $extraArgs);
     }
 
     public function testIsSubclassOfGeometry()

--- a/tests/GeoJson/Tests/Geometry/MultiLineStringTest.php
+++ b/tests/GeoJson/Tests/Geometry/MultiLineStringTest.php
@@ -7,12 +7,13 @@ use GeoJson\Geometry\LineString;
 use GeoJson\Geometry\MultiLineString;
 use GeoJson\Tests\BaseGeoJsonTest;
 use GeoJson\Geometry\Geometry;
+use ReflectionClass;
 
 class MultiLineStringTest extends BaseGeoJsonTest
 {
     public function createSubjectWithExtraArguments(array $extraArgs)
     {
-        $class = new \ReflectionClass(MultiLineString::class);
+        $class = new ReflectionClass(MultiLineString::class);
 
         return $class->newInstanceArgs(array_merge(
             array(array(

--- a/tests/GeoJson/Tests/Geometry/MultiLineStringTest.php
+++ b/tests/GeoJson/Tests/Geometry/MultiLineStringTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Tests\Geometry;
 
 use GeoJson\GeoJson;
@@ -8,46 +10,49 @@ use GeoJson\Geometry\LineString;
 use GeoJson\Geometry\MultiLineString;
 use GeoJson\Tests\BaseGeoJsonTest;
 
+use function is_subclass_of;
+use function json_decode;
+
 class MultiLineStringTest extends BaseGeoJsonTest
 {
-    public function createSubjectWithExtraArguments(... $extraArgs)
+    public function createSubjectWithExtraArguments(...$extraArgs)
     {
         return new MultiLineString([], ... $extraArgs);
     }
 
-    public function testIsSubclassOfGeometry()
+    public function testIsSubclassOfGeometry(): void
     {
         $this->assertTrue(is_subclass_of(MultiLineString::class, Geometry::class));
     }
 
-    public function testConstructionFromLineStringObjects()
+    public function testConstructionFromLineStringObjects(): void
     {
-        $multiLineString1 = new MultiLineString(array(
-            new LineString(array(array(1, 1), array(2, 2))),
-            new LineString(array(array(3, 3), array(4, 4))),
-        ));
+        $multiLineString1 = new MultiLineString([
+            new LineString([[1, 1], [2, 2]]),
+            new LineString([[3, 3], [4, 4]]),
+        ]);
 
-        $multiLineString2 = new MultiLineString(array(
-            array(array(1, 1), array(2, 2)),
-            array(array(3, 3), array(4, 4)),
-        ));
+        $multiLineString2 = new MultiLineString([
+            [[1, 1], [2, 2]],
+            [[3, 3], [4, 4]],
+        ]);
 
         $this->assertSame($multiLineString1->getCoordinates(), $multiLineString2->getCoordinates());
     }
 
-    public function testSerialization()
+    public function testSerialization(): void
     {
-        $coordinates = array(
-            array(array(1, 1), array(2, 2)),
-            array(array(3, 3), array(4, 4)),
-        );
+        $coordinates = [
+            [[1, 1], [2, 2]],
+            [[3, 3], [4, 4]],
+        ];
 
         $multiLineString = new MultiLineString($coordinates);
 
-        $expected = array(
+        $expected = [
             'type' => 'MultiLineString',
             'coordinates' => $coordinates,
-        );
+        ];
 
         $this->assertSame('MultiLineString', $multiLineString->getType());
         $this->assertSame($coordinates, $multiLineString->getCoordinates());
@@ -58,7 +63,7 @@ class MultiLineStringTest extends BaseGeoJsonTest
      * @dataProvider provideJsonDecodeAssocOptions
      * @group functional
      */
-    public function testUnserialization($assoc)
+    public function testUnserialization($assoc): void
     {
         $json = <<<'JSON'
 {
@@ -73,10 +78,10 @@ JSON;
         $json = json_decode($json, $assoc);
         $multiLineString = GeoJson::jsonUnserialize($json);
 
-        $expectedCoordinates = array(
-            array(array(1, 1), array(2, 2)),
-            array(array(3, 3), array(4, 4)),
-        );
+        $expectedCoordinates = [
+            [[1, 1], [2, 2]],
+            [[3, 3], [4, 4]],
+        ];
 
         $this->assertInstanceOf(MultiLineString::class, $multiLineString);
         $this->assertSame('MultiLineString', $multiLineString->getType());
@@ -85,9 +90,9 @@ JSON;
 
     public function provideJsonDecodeAssocOptions()
     {
-        return array(
-            'assoc=true' => array(true),
-            'assoc=false' => array(false),
-        );
+        return [
+            'assoc=true' => [true],
+            'assoc=false' => [false],
+        ];
     }
 }

--- a/tests/GeoJson/Tests/Geometry/MultiLineStringTest.php
+++ b/tests/GeoJson/Tests/Geometry/MultiLineStringTest.php
@@ -6,12 +6,13 @@ use GeoJson\GeoJson;
 use GeoJson\Geometry\LineString;
 use GeoJson\Geometry\MultiLineString;
 use GeoJson\Tests\BaseGeoJsonTest;
+use GeoJson\Geometry\Geometry;
 
 class MultiLineStringTest extends BaseGeoJsonTest
 {
     public function createSubjectWithExtraArguments(array $extraArgs)
     {
-        $class = new \ReflectionClass('GeoJson\Geometry\MultiLineString');
+        $class = new \ReflectionClass(MultiLineString::class);
 
         return $class->newInstanceArgs(array_merge(
             array(array(
@@ -24,7 +25,7 @@ class MultiLineStringTest extends BaseGeoJsonTest
 
     public function testIsSubclassOfGeometry()
     {
-        $this->assertTrue(is_subclass_of('GeoJson\Geometry\MultiLineString', 'GeoJson\Geometry\Geometry'));
+        $this->assertTrue(is_subclass_of(MultiLineString::class, Geometry::class));
     }
 
     public function testConstructionFromLineStringObjects()
@@ -85,7 +86,7 @@ JSON;
             array(array(3, 3), array(4, 4)),
         );
 
-        $this->assertInstanceOf('GeoJson\Geometry\MultiLineString', $multiLineString);
+        $this->assertInstanceOf(MultiLineString::class, $multiLineString);
         $this->assertSame('MultiLineString', $multiLineString->getType());
         $this->assertSame($expectedCoordinates, $multiLineString->getCoordinates());
     }

--- a/tests/GeoJson/Tests/Geometry/MultiPointTest.php
+++ b/tests/GeoJson/Tests/Geometry/MultiPointTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Tests\Geometry;
 
 use GeoJson\GeoJson;
@@ -8,42 +10,45 @@ use GeoJson\Geometry\MultiPoint;
 use GeoJson\Geometry\Point;
 use GeoJson\Tests\BaseGeoJsonTest;
 
+use function is_subclass_of;
+use function json_decode;
+
 class MultiPointTest extends BaseGeoJsonTest
 {
-    public function createSubjectWithExtraArguments(... $extraArgs)
+    public function createSubjectWithExtraArguments(...$extraArgs)
     {
         return new MultiPoint([], ... $extraArgs);
     }
 
-    public function testIsSubclassOfGeometry()
+    public function testIsSubclassOfGeometry(): void
     {
         $this->assertTrue(is_subclass_of(MultiPoint::class, Geometry::class));
     }
 
-    public function testConstructionFromPointObjects()
+    public function testConstructionFromPointObjects(): void
     {
-        $multiPoint1 = new MultiPoint(array(
-            new Point(array(1, 1)),
-            new Point(array(2, 2)),
-        ));
+        $multiPoint1 = new MultiPoint([
+            new Point([1, 1]),
+            new Point([2, 2]),
+        ]);
 
-        $multiPoint2 = new MultiPoint(array(
-            array(1, 1),
-            array(2, 2),
-        ));
+        $multiPoint2 = new MultiPoint([
+            [1, 1],
+            [2, 2],
+        ]);
 
         $this->assertSame($multiPoint1->getCoordinates(), $multiPoint2->getCoordinates());
     }
 
-    public function testSerialization()
+    public function testSerialization(): void
     {
-        $coordinates = array(array(1, 1), array(2, 2));
+        $coordinates = [[1, 1], [2, 2]];
         $multiPoint = new MultiPoint($coordinates);
 
-        $expected = array(
+        $expected = [
             'type' => 'MultiPoint',
             'coordinates' => $coordinates,
-        );
+        ];
 
         $this->assertSame('MultiPoint', $multiPoint->getType());
         $this->assertSame($coordinates, $multiPoint->getCoordinates());
@@ -54,7 +59,7 @@ class MultiPointTest extends BaseGeoJsonTest
      * @dataProvider provideJsonDecodeAssocOptions
      * @group functional
      */
-    public function testUnserialization($assoc)
+    public function testUnserialization($assoc): void
     {
         $json = <<<'JSON'
 {
@@ -69,7 +74,7 @@ JSON;
         $json = json_decode($json, $assoc);
         $multiPoint = GeoJson::jsonUnserialize($json);
 
-        $expectedCoordinates = array(array(1, 1), array(2, 2));
+        $expectedCoordinates = [[1, 1], [2, 2]];
 
         $this->assertInstanceOf(MultiPoint::class, $multiPoint);
         $this->assertSame('MultiPoint', $multiPoint->getType());
@@ -78,9 +83,9 @@ JSON;
 
     public function provideJsonDecodeAssocOptions()
     {
-        return array(
-            'assoc=true' => array(true),
-            'assoc=false' => array(false),
-        );
+        return [
+            'assoc=true' => [true],
+            'assoc=false' => [false],
+        ];
     }
 }

--- a/tests/GeoJson/Tests/Geometry/MultiPointTest.php
+++ b/tests/GeoJson/Tests/Geometry/MultiPointTest.php
@@ -3,25 +3,16 @@
 namespace GeoJson\Tests\Geometry;
 
 use GeoJson\GeoJson;
+use GeoJson\Geometry\Geometry;
 use GeoJson\Geometry\MultiPoint;
 use GeoJson\Geometry\Point;
 use GeoJson\Tests\BaseGeoJsonTest;
-use GeoJson\Geometry\Geometry;
-use ReflectionClass;
 
 class MultiPointTest extends BaseGeoJsonTest
 {
-    public function createSubjectWithExtraArguments(array $extraArgs)
+    public function createSubjectWithExtraArguments(... $extraArgs)
     {
-        $class = new ReflectionClass(MultiPoint::class);
-
-        return $class->newInstanceArgs(array_merge(
-            array(array(
-                array(1, 1),
-                array(2, 2),
-            )),
-            $extraArgs
-        ));
+        return new MultiPoint([], ... $extraArgs);
     }
 
     public function testIsSubclassOfGeometry()

--- a/tests/GeoJson/Tests/Geometry/MultiPointTest.php
+++ b/tests/GeoJson/Tests/Geometry/MultiPointTest.php
@@ -7,12 +7,13 @@ use GeoJson\Geometry\MultiPoint;
 use GeoJson\Geometry\Point;
 use GeoJson\Tests\BaseGeoJsonTest;
 use GeoJson\Geometry\Geometry;
+use ReflectionClass;
 
 class MultiPointTest extends BaseGeoJsonTest
 {
     public function createSubjectWithExtraArguments(array $extraArgs)
     {
-        $class = new \ReflectionClass(MultiPoint::class);
+        $class = new ReflectionClass(MultiPoint::class);
 
         return $class->newInstanceArgs(array_merge(
             array(array(

--- a/tests/GeoJson/Tests/Geometry/MultiPointTest.php
+++ b/tests/GeoJson/Tests/Geometry/MultiPointTest.php
@@ -6,12 +6,13 @@ use GeoJson\GeoJson;
 use GeoJson\Geometry\MultiPoint;
 use GeoJson\Geometry\Point;
 use GeoJson\Tests\BaseGeoJsonTest;
+use GeoJson\Geometry\Geometry;
 
 class MultiPointTest extends BaseGeoJsonTest
 {
     public function createSubjectWithExtraArguments(array $extraArgs)
     {
-        $class = new \ReflectionClass('GeoJson\Geometry\MultiPoint');
+        $class = new \ReflectionClass(MultiPoint::class);
 
         return $class->newInstanceArgs(array_merge(
             array(array(
@@ -24,7 +25,7 @@ class MultiPointTest extends BaseGeoJsonTest
 
     public function testIsSubclassOfGeometry()
     {
-        $this->assertTrue(is_subclass_of('GeoJson\Geometry\MultiPoint', 'GeoJson\Geometry\Geometry'));
+        $this->assertTrue(is_subclass_of(MultiPoint::class, Geometry::class));
     }
 
     public function testConstructionFromPointObjects()
@@ -78,7 +79,7 @@ JSON;
 
         $expectedCoordinates = array(array(1, 1), array(2, 2));
 
-        $this->assertInstanceOf('GeoJson\Geometry\MultiPoint', $multiPoint);
+        $this->assertInstanceOf(MultiPoint::class, $multiPoint);
         $this->assertSame('MultiPoint', $multiPoint->getType());
         $this->assertSame($expectedCoordinates, $multiPoint->getCoordinates());
     }

--- a/tests/GeoJson/Tests/Geometry/MultiPolygonTest.php
+++ b/tests/GeoJson/Tests/Geometry/MultiPolygonTest.php
@@ -7,12 +7,13 @@ use GeoJson\Geometry\MultiPolygon;
 use GeoJson\Geometry\Polygon;
 use GeoJson\Tests\BaseGeoJsonTest;
 use GeoJson\Geometry\Geometry;
+use ReflectionClass;
 
 class MultiPolygonTest extends BaseGeoJsonTest
 {
     public function createSubjectWithExtraArguments(array $extraArgs)
     {
-        $class = new \ReflectionClass(MultiPolygon::class);
+        $class = new ReflectionClass(MultiPolygon::class);
 
         return $class->newInstanceArgs(array_merge(
             array(array(

--- a/tests/GeoJson/Tests/Geometry/MultiPolygonTest.php
+++ b/tests/GeoJson/Tests/Geometry/MultiPolygonTest.php
@@ -3,25 +3,16 @@
 namespace GeoJson\Tests\Geometry;
 
 use GeoJson\GeoJson;
+use GeoJson\Geometry\Geometry;
 use GeoJson\Geometry\MultiPolygon;
 use GeoJson\Geometry\Polygon;
 use GeoJson\Tests\BaseGeoJsonTest;
-use GeoJson\Geometry\Geometry;
-use ReflectionClass;
 
 class MultiPolygonTest extends BaseGeoJsonTest
 {
-    public function createSubjectWithExtraArguments(array $extraArgs)
+    public function createSubjectWithExtraArguments(... $extraArgs)
     {
-        $class = new ReflectionClass(MultiPolygon::class);
-
-        return $class->newInstanceArgs(array_merge(
-            array(array(
-                array(array(array(0, 0), array(0, 4), array(4, 4), array(4, 0), array(0, 0))),
-                array(array(array(1, 1), array(1, 3), array(3, 3), array(3, 1), array(1, 1))),
-            )),
-            $extraArgs
-        ));
+        return new MultiPolygon([], ... $extraArgs);
     }
 
     public function testIsSubclassOfGeometry()

--- a/tests/GeoJson/Tests/Geometry/MultiPolygonTest.php
+++ b/tests/GeoJson/Tests/Geometry/MultiPolygonTest.php
@@ -6,12 +6,13 @@ use GeoJson\GeoJson;
 use GeoJson\Geometry\MultiPolygon;
 use GeoJson\Geometry\Polygon;
 use GeoJson\Tests\BaseGeoJsonTest;
+use GeoJson\Geometry\Geometry;
 
 class MultiPolygonTest extends BaseGeoJsonTest
 {
     public function createSubjectWithExtraArguments(array $extraArgs)
     {
-        $class = new \ReflectionClass('GeoJson\Geometry\MultiPolygon');
+        $class = new \ReflectionClass(MultiPolygon::class);
 
         return $class->newInstanceArgs(array_merge(
             array(array(
@@ -24,7 +25,7 @@ class MultiPolygonTest extends BaseGeoJsonTest
 
     public function testIsSubclassOfGeometry()
     {
-        $this->assertTrue(is_subclass_of('GeoJson\Geometry\MultiPolygon', 'GeoJson\Geometry\Geometry'));
+        $this->assertTrue(is_subclass_of(MultiPolygon::class, Geometry::class));
     }
 
     public function testConstructionFromPolygonObjects()
@@ -85,7 +86,7 @@ JSON;
             array(array(array(1, 1), array(1, 3), array(3, 3), array(3, 1), array(1, 1))),
         );
 
-        $this->assertInstanceOf('GeoJson\Geometry\MultiPolygon', $multiPolygon);
+        $this->assertInstanceOf(MultiPolygon::class, $multiPolygon);
         $this->assertSame('MultiPolygon', $multiPolygon->getType());
         $this->assertSame($expectedCoordinates, $multiPolygon->getCoordinates());
     }

--- a/tests/GeoJson/Tests/Geometry/MultiPolygonTest.php
+++ b/tests/GeoJson/Tests/Geometry/MultiPolygonTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Tests\Geometry;
 
 use GeoJson\GeoJson;
@@ -8,46 +10,49 @@ use GeoJson\Geometry\MultiPolygon;
 use GeoJson\Geometry\Polygon;
 use GeoJson\Tests\BaseGeoJsonTest;
 
+use function is_subclass_of;
+use function json_decode;
+
 class MultiPolygonTest extends BaseGeoJsonTest
 {
-    public function createSubjectWithExtraArguments(... $extraArgs)
+    public function createSubjectWithExtraArguments(...$extraArgs)
     {
         return new MultiPolygon([], ... $extraArgs);
     }
 
-    public function testIsSubclassOfGeometry()
+    public function testIsSubclassOfGeometry(): void
     {
         $this->assertTrue(is_subclass_of(MultiPolygon::class, Geometry::class));
     }
 
-    public function testConstructionFromPolygonObjects()
+    public function testConstructionFromPolygonObjects(): void
     {
-        $multiPolygon1 = new MultiPolygon(array(
-            new Polygon(array(array(array(0, 0), array(0, 4), array(4, 4), array(4, 0), array(0, 0)))),
-            new Polygon(array(array(array(1, 1), array(1, 3), array(3, 3), array(3, 1), array(1, 1)))),
-        ));
+        $multiPolygon1 = new MultiPolygon([
+            new Polygon([[[0, 0], [0, 4], [4, 4], [4, 0], [0, 0]]]),
+            new Polygon([[[1, 1], [1, 3], [3, 3], [3, 1], [1, 1]]]),
+        ]);
 
-        $multiPolygon2 = new MultiPolygon(array(
-            array(array(array(0, 0), array(0, 4), array(4, 4), array(4, 0), array(0, 0))),
-            array(array(array(1, 1), array(1, 3), array(3, 3), array(3, 1), array(1, 1))),
-        ));
+        $multiPolygon2 = new MultiPolygon([
+            [[[0, 0], [0, 4], [4, 4], [4, 0], [0, 0]]],
+            [[[1, 1], [1, 3], [3, 3], [3, 1], [1, 1]]],
+        ]);
 
         $this->assertSame($multiPolygon1->getCoordinates(), $multiPolygon2->getCoordinates());
     }
 
-    public function testSerialization()
+    public function testSerialization(): void
     {
-        $coordinates = array(
-            array(array(array(0, 0), array(0, 4), array(4, 4), array(4, 0), array(0, 0))),
-            array(array(array(1, 1), array(1, 3), array(3, 3), array(3, 1), array(1, 1))),
-        );
+        $coordinates = [
+            [[[0, 0], [0, 4], [4, 4], [4, 0], [0, 0]]],
+            [[[1, 1], [1, 3], [3, 3], [3, 1], [1, 1]]],
+        ];
 
         $multiPolygon = new MultiPolygon($coordinates);
 
-        $expected = array(
+        $expected = [
             'type' => 'MultiPolygon',
             'coordinates' => $coordinates,
-        );
+        ];
 
         $this->assertSame('MultiPolygon', $multiPolygon->getType());
         $this->assertSame($coordinates, $multiPolygon->getCoordinates());
@@ -58,7 +63,7 @@ class MultiPolygonTest extends BaseGeoJsonTest
      * @dataProvider provideJsonDecodeAssocOptions
      * @group functional
      */
-    public function testUnserialization($assoc)
+    public function testUnserialization($assoc): void
     {
         $json = <<<'JSON'
 {
@@ -73,10 +78,10 @@ JSON;
         $json = json_decode($json, $assoc);
         $multiPolygon = GeoJson::jsonUnserialize($json);
 
-        $expectedCoordinates = array(
-            array(array(array(0, 0), array(0, 4), array(4, 4), array(4, 0), array(0, 0))),
-            array(array(array(1, 1), array(1, 3), array(3, 3), array(3, 1), array(1, 1))),
-        );
+        $expectedCoordinates = [
+            [[[0, 0], [0, 4], [4, 4], [4, 0], [0, 0]]],
+            [[[1, 1], [1, 3], [3, 3], [3, 1], [1, 1]]],
+        ];
 
         $this->assertInstanceOf(MultiPolygon::class, $multiPolygon);
         $this->assertSame('MultiPolygon', $multiPolygon->getType());
@@ -85,9 +90,9 @@ JSON;
 
     public function provideJsonDecodeAssocOptions()
     {
-        return array(
-            'assoc=true' => array(true),
-            'assoc=false' => array(false),
-        );
+        return [
+            'assoc=true' => [true],
+            'assoc=false' => [false],
+        ];
     }
 }

--- a/tests/GeoJson/Tests/Geometry/PointTest.php
+++ b/tests/GeoJson/Tests/Geometry/PointTest.php
@@ -3,20 +3,17 @@
 namespace GeoJson\Tests\Geometry;
 
 use GeoJson\GeoJson;
+use GeoJson\Geometry\Geometry;
 use GeoJson\Geometry\Point;
 use GeoJson\Tests\BaseGeoJsonTest;
 use InvalidArgumentException;
-use GeoJson\Geometry\Geometry;
-use ReflectionClass;
 use stdClass;
 
 class PointTest extends BaseGeoJsonTest
 {
-    public function createSubjectWithExtraArguments(array $extraArgs)
+    public function createSubjectWithExtraArguments(... $extraArgs)
     {
-        $class = new ReflectionClass(Point::class);
-
-        return $class->newInstanceArgs(array_merge(array(array(1, 1)), $extraArgs));
+        return new Point([1, 1], ... $extraArgs);
     }
 
     public function testIsSubclassOfGeometry()

--- a/tests/GeoJson/Tests/Geometry/PointTest.php
+++ b/tests/GeoJson/Tests/Geometry/PointTest.php
@@ -7,12 +7,14 @@ use GeoJson\Geometry\Point;
 use GeoJson\Tests\BaseGeoJsonTest;
 use InvalidArgumentException;
 use GeoJson\Geometry\Geometry;
+use ReflectionClass;
+use stdClass;
 
 class PointTest extends BaseGeoJsonTest
 {
     public function createSubjectWithExtraArguments(array $extraArgs)
     {
-        $class = new \ReflectionClass(Point::class);
+        $class = new ReflectionClass(Point::class);
 
         return $class->newInstanceArgs(array_merge(array(array(1, 1)), $extraArgs));
     }
@@ -45,7 +47,7 @@ class PointTest extends BaseGeoJsonTest
     {
         return array(
             'strings' => array('1.0', '2'),
-            'objects' => array(new \stdClass(), new \stdClass()),
+            'objects' => array(new stdClass(), new stdClass()),
             'arrays' => array(array(), array()),
         );
     }

--- a/tests/GeoJson/Tests/Geometry/PointTest.php
+++ b/tests/GeoJson/Tests/Geometry/PointTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Tests\Geometry;
 
 use GeoJson\GeoJson;
@@ -9,30 +11,34 @@ use GeoJson\Tests\BaseGeoJsonTest;
 use InvalidArgumentException;
 use stdClass;
 
+use function is_subclass_of;
+use function func_get_args;
+use function json_decode;
+
 class PointTest extends BaseGeoJsonTest
 {
-    public function createSubjectWithExtraArguments(... $extraArgs)
+    public function createSubjectWithExtraArguments(...$extraArgs)
     {
         return new Point([1, 1], ... $extraArgs);
     }
 
-    public function testIsSubclassOfGeometry()
+    public function testIsSubclassOfGeometry(): void
     {
         $this->assertTrue(is_subclass_of(Point::class, Geometry::class));
     }
 
-    public function testConstructorShouldRequireAtLeastTwoElementsInPosition()
+    public function testConstructorShouldRequireAtLeastTwoElementsInPosition(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Position requires at least two elements');
 
-        new Point(array(1));
+        new Point([1]);
     }
 
     /**
      * @dataProvider providePositionsWithInvalidTypes
      */
-    public function testConstructorShouldRequireIntegerOrFloatElementsInPosition()
+    public function testConstructorShouldRequireIntegerOrFloatElementsInPosition(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Position elements must be integers or floats');
@@ -42,29 +48,29 @@ class PointTest extends BaseGeoJsonTest
 
     public function providePositionsWithInvalidTypes()
     {
-        return array(
-            'strings' => array('1.0', '2'),
-            'objects' => array(new stdClass(), new stdClass()),
-            'arrays' => array(array(), array()),
-        );
+        return [
+            'strings' => ['1.0', '2'],
+            'objects' => [new stdClass(), new stdClass()],
+            'arrays' => [[], []],
+        ];
     }
 
-    public function testConstructorShouldAllowMoreThanTwoElementsInAPosition()
+    public function testConstructorShouldAllowMoreThanTwoElementsInAPosition(): void
     {
-        $point = new Point(array(1, 2, 3, 4));
+        $point = new Point([1, 2, 3, 4]);
 
-        $this->assertEquals(array(1, 2, 3, 4), $point->getCoordinates());
+        $this->assertEquals([1, 2, 3, 4], $point->getCoordinates());
     }
 
-    public function testSerialization()
+    public function testSerialization(): void
     {
-        $coordinates = array(1, 1);
+        $coordinates = [1, 1];
         $point = new Point($coordinates);
 
-        $expected = array(
+        $expected = [
             'type' => 'Point',
             'coordinates' => $coordinates,
-        );
+        ];
 
         $this->assertSame('Point', $point->getType());
         $this->assertSame($coordinates, $point->getCoordinates());
@@ -75,7 +81,7 @@ class PointTest extends BaseGeoJsonTest
      * @dataProvider provideJsonDecodeAssocOptions
      * @group functional
      */
-    public function testUnserialization($assoc)
+    public function testUnserialization($assoc): void
     {
         $json = <<<'JSON'
 {
@@ -89,14 +95,14 @@ JSON;
 
         $this->assertInstanceOf(Point::class, $point);
         $this->assertSame('Point', $point->getType());
-        $this->assertSame(array(1, 1), $point->getCoordinates());
+        $this->assertSame([1, 1], $point->getCoordinates());
     }
 
     public function provideJsonDecodeAssocOptions()
     {
-        return array(
-            'assoc=true' => array(true),
-            'assoc=false' => array(false),
-        );
+        return [
+            'assoc=true' => [true],
+            'assoc=false' => [false],
+        ];
     }
 }

--- a/tests/GeoJson/Tests/Geometry/PointTest.php
+++ b/tests/GeoJson/Tests/Geometry/PointTest.php
@@ -6,19 +6,20 @@ use GeoJson\GeoJson;
 use GeoJson\Geometry\Point;
 use GeoJson\Tests\BaseGeoJsonTest;
 use InvalidArgumentException;
+use GeoJson\Geometry\Geometry;
 
 class PointTest extends BaseGeoJsonTest
 {
     public function createSubjectWithExtraArguments(array $extraArgs)
     {
-        $class = new \ReflectionClass('GeoJson\Geometry\Point');
+        $class = new \ReflectionClass(Point::class);
 
         return $class->newInstanceArgs(array_merge(array(array(1, 1)), $extraArgs));
     }
 
     public function testIsSubclassOfGeometry()
     {
-        $this->assertTrue(is_subclass_of('GeoJson\Geometry\Point', 'GeoJson\Geometry\Geometry'));
+        $this->assertTrue(is_subclass_of(Point::class, Geometry::class));
     }
 
     public function testConstructorShouldRequireAtLeastTwoElementsInPosition()
@@ -87,7 +88,7 @@ JSON;
         $json = json_decode($json, $assoc);
         $point = GeoJson::jsonUnserialize($json);
 
-        $this->assertInstanceOf('GeoJson\Geometry\Point', $point);
+        $this->assertInstanceOf(Point::class, $point);
         $this->assertSame('Point', $point->getType());
         $this->assertSame(array(1, 1), $point->getCoordinates());
     }

--- a/tests/GeoJson/Tests/Geometry/PolygonTest.php
+++ b/tests/GeoJson/Tests/Geometry/PolygonTest.php
@@ -6,12 +6,13 @@ use GeoJson\GeoJson;
 use GeoJson\Geometry\LinearRing;
 use GeoJson\Geometry\Polygon;
 use GeoJson\Tests\BaseGeoJsonTest;
+use GeoJson\Geometry\Geometry;
 
 class PolygonTest extends BaseGeoJsonTest
 {
     public function createSubjectWithExtraArguments(array $extraArgs)
     {
-        $class = new \ReflectionClass('GeoJson\Geometry\Polygon');
+        $class = new \ReflectionClass(Polygon::class);
 
         return $class->newInstanceArgs(array_merge(
             array(array(
@@ -24,7 +25,7 @@ class PolygonTest extends BaseGeoJsonTest
 
     public function testIsSubclassOfGeometry()
     {
-        $this->assertTrue(is_subclass_of('GeoJson\Geometry\Polygon', 'GeoJson\Geometry\Geometry'));
+        $this->assertTrue(is_subclass_of(Polygon::class, Geometry::class));
     }
 
     public function testConstructionFromLinearRingObjects()
@@ -85,7 +86,7 @@ JSON;
             array(array(1, 1), array(1, 3), array(3, 3), array(3, 1), array(1, 1)),
         );
 
-        $this->assertInstanceOf('GeoJson\Geometry\Polygon', $polygon);
+        $this->assertInstanceOf(Polygon::class, $polygon);
         $this->assertSame('Polygon', $polygon->getType());
         $this->assertSame($expectedCoordinates, $polygon->getCoordinates());
     }

--- a/tests/GeoJson/Tests/Geometry/PolygonTest.php
+++ b/tests/GeoJson/Tests/Geometry/PolygonTest.php
@@ -7,12 +7,13 @@ use GeoJson\Geometry\LinearRing;
 use GeoJson\Geometry\Polygon;
 use GeoJson\Tests\BaseGeoJsonTest;
 use GeoJson\Geometry\Geometry;
+use ReflectionClass;
 
 class PolygonTest extends BaseGeoJsonTest
 {
     public function createSubjectWithExtraArguments(array $extraArgs)
     {
-        $class = new \ReflectionClass(Polygon::class);
+        $class = new ReflectionClass(Polygon::class);
 
         return $class->newInstanceArgs(array_merge(
             array(array(

--- a/tests/GeoJson/Tests/Geometry/PolygonTest.php
+++ b/tests/GeoJson/Tests/Geometry/PolygonTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GeoJson\Tests\Geometry;
 
 use GeoJson\GeoJson;
@@ -8,52 +10,55 @@ use GeoJson\Geometry\LinearRing;
 use GeoJson\Geometry\Polygon;
 use GeoJson\Tests\BaseGeoJsonTest;
 
+use function is_subclass_of;
+use function json_decode;
+
 class PolygonTest extends BaseGeoJsonTest
 {
-    public function createSubjectWithExtraArguments(... $extraArgs)
+    public function createSubjectWithExtraArguments(...$extraArgs)
     {
         return new Polygon(
-            array(
-                array(array(0, 0), array(0, 4), array(4, 4), array(4, 0), array(0, 0)),
-                array(array(1, 1), array(1, 3), array(3, 3), array(3, 1), array(1, 1)),
-            ),
+            [
+                [[0, 0], [0, 4], [4, 4], [4, 0], [0, 0]],
+                [[1, 1], [1, 3], [3, 3], [3, 1], [1, 1]],
+            ],
             ... $extraArgs
         );
     }
 
-    public function testIsSubclassOfGeometry()
+    public function testIsSubclassOfGeometry(): void
     {
         $this->assertTrue(is_subclass_of(Polygon::class, Geometry::class));
     }
 
-    public function testConstructionFromLinearRingObjects()
+    public function testConstructionFromLinearRingObjects(): void
     {
-        $polygon1 = new Polygon(array(
-            new LinearRing(array(array(0, 0), array(0, 4), array(4, 4), array(4, 0), array(0, 0))),
-            new LinearRing(array(array(1, 1), array(1, 3), array(3, 3), array(3, 1), array(1, 1))),
-        ));
+        $polygon1 = new Polygon([
+            new LinearRing([[0, 0], [0, 4], [4, 4], [4, 0], [0, 0]]),
+            new LinearRing([[1, 1], [1, 3], [3, 3], [3, 1], [1, 1]]),
+        ]);
 
-        $polygon2 = new Polygon(array(
-            array(array(0, 0), array(0, 4), array(4, 4), array(4, 0), array(0, 0)),
-            array(array(1, 1), array(1, 3), array(3, 3), array(3, 1), array(1, 1)),
-        ));
+        $polygon2 = new Polygon([
+            [[0, 0], [0, 4], [4, 4], [4, 0], [0, 0]],
+            [[1, 1], [1, 3], [3, 3], [3, 1], [1, 1]],
+        ]);
 
         $this->assertSame($polygon1->getCoordinates(), $polygon2->getCoordinates());
     }
 
-    public function testSerialization()
+    public function testSerialization(): void
     {
-        $coordinates = array(
-            array(array(0, 0), array(0, 4), array(4, 4), array(4, 0), array(0, 0)),
-            array(array(1, 1), array(1, 3), array(3, 3), array(3, 1), array(1, 1)),
-        );
+        $coordinates = [
+            [[0, 0], [0, 4], [4, 4], [4, 0], [0, 0]],
+            [[1, 1], [1, 3], [3, 3], [3, 1], [1, 1]],
+        ];
 
         $polygon = new Polygon($coordinates);
 
-        $expected = array(
+        $expected = [
             'type' => 'Polygon',
             'coordinates' => $coordinates,
-        );
+        ];
 
         $this->assertSame('Polygon', $polygon->getType());
         $this->assertSame($coordinates, $polygon->getCoordinates());
@@ -64,7 +69,7 @@ class PolygonTest extends BaseGeoJsonTest
      * @dataProvider provideJsonDecodeAssocOptions
      * @group functional
      */
-    public function testUnserialization($assoc)
+    public function testUnserialization($assoc): void
     {
         $json = <<<'JSON'
 {
@@ -79,10 +84,10 @@ JSON;
         $json = json_decode($json, $assoc);
         $polygon = GeoJson::jsonUnserialize($json);
 
-        $expectedCoordinates = array(
-            array(array(0, 0), array(0, 4), array(4, 4), array(4, 0), array(0, 0)),
-            array(array(1, 1), array(1, 3), array(3, 3), array(3, 1), array(1, 1)),
-        );
+        $expectedCoordinates = [
+            [[0, 0], [0, 4], [4, 4], [4, 0], [0, 0]],
+            [[1, 1], [1, 3], [3, 3], [3, 1], [1, 1]],
+        ];
 
         $this->assertInstanceOf(Polygon::class, $polygon);
         $this->assertSame('Polygon', $polygon->getType());
@@ -91,9 +96,9 @@ JSON;
 
     public function provideJsonDecodeAssocOptions()
     {
-        return array(
-            'assoc=true' => array(true),
-            'assoc=false' => array(false),
-        );
+        return [
+            'assoc=true' => [true],
+            'assoc=false' => [false],
+        ];
     }
 }

--- a/tests/GeoJson/Tests/Geometry/PolygonTest.php
+++ b/tests/GeoJson/Tests/Geometry/PolygonTest.php
@@ -3,25 +3,22 @@
 namespace GeoJson\Tests\Geometry;
 
 use GeoJson\GeoJson;
+use GeoJson\Geometry\Geometry;
 use GeoJson\Geometry\LinearRing;
 use GeoJson\Geometry\Polygon;
 use GeoJson\Tests\BaseGeoJsonTest;
-use GeoJson\Geometry\Geometry;
-use ReflectionClass;
 
 class PolygonTest extends BaseGeoJsonTest
 {
-    public function createSubjectWithExtraArguments(array $extraArgs)
+    public function createSubjectWithExtraArguments(... $extraArgs)
     {
-        $class = new ReflectionClass(Polygon::class);
-
-        return $class->newInstanceArgs(array_merge(
-            array(array(
+        return new Polygon(
+            array(
                 array(array(0, 0), array(0, 4), array(4, 4), array(4, 0), array(0, 0)),
                 array(array(1, 1), array(1, 3), array(3, 3), array(3, 1), array(1, 1)),
-            )),
-            $extraArgs
-        ));
+            ),
+            ... $extraArgs
+        );
     }
 
     public function testIsSubclassOfGeometry()

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,7 +1,0 @@
-<?php
-
-if (!file_exists($autoloadFile = __DIR__.'/../vendor/autoload.php')) {
-    throw new RuntimeException('Install dependencies to run test suite.');
-}
-
-require_once $autoloadFile;


### PR DESCRIPTION
Hey there 👋,

as promised (threatened 😅), here's my follow-up PR. Since we can now expect to be on at least PHP 7.4 and PHPUnit 9.5, there are some improvements that can be applied.

I tried to be as atomic as possible, with each commit message describing what it is about, but I think some of the changes warrant a little more context:

* Since we now have type-hints, PHPDocs are even more meant for documentation rather than support for IDEs or API Doc generation. That's the reason why I removed all property, argument and return value annotations that are already visible through the type hints.
* There's no need for reflection or `func_get_args()` anymore \o/
* According to the RFC, the "id" property of a `Feature` is expected to be a JSON string or a number (https://www.rfc-editor.org/rfc/rfc7946#section-3.2), so I added a check for this. This would be a breaking change, so if you're targeting a 1.1 release instead of a 2.0 release, I can remove the check again.
* Testing the unhappy paths of the `GeoJson::unserialize()` method is not strictly part of the language level migration, but it was the only method that prevented a [100% code coverage](https://scrutinizer-ci.com/g/jmikola/geojson/inspections/551abb81-a0c8-473a-9fb3-09ca71f142fd) and even if its importance can be disputed, I still think that it's a nice metric 😅
* The `array<...>` notation in DocBlocks is used to avoid consecutive `[][][]`s and to make it a little bit easier to make out the supported types - especially for the nested ones. The changes should enable IDEs like PHPStorm to provide autocompletion and Static Code Analysis Tools like PHPStan to parse them.

:octocat: 

Closes #21 
Closes #22 
Closes #30