### PR TITLE
enhance php8.1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,42 +1,49 @@
 {
-    "name": "jmikola/geojson",
-    "type": "library",
-    "description": "GeoJSON implementation for PHP",
-    "keywords": ["geo", "geospatial", "geojson"],
-    "homepage": "https://github.com/jmikola/geojson",
-    "license": "MIT",
-    "authors": [
-        { "name": "Jeremy Mikola", "email": "jmikola@gmail.com" }
-    ],
-    "require": {
-        "php": "^7.4 || ^8.0",
-        "ext-json": "*",
-        "symfony/polyfill-php80": "^1.25"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^9.5",
-        "scrutinizer/ocular": "^1.8.1",
-        "squizlabs/php_codesniffer": "^3.6",
-        "slevomat/coding-standard": "^7.0"
-    },
-    "autoload": {
-        "psr-4": {
-            "GeoJson\\": "src"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "GeoJson\\Tests\\": "tests"
-        }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.1-dev"
-        }
-    },
-    "config": {
-        "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
-        }
+  "name": "jmikola/geojson",
+  "type": "library",
+  "description": "GeoJSON implementation for PHP",
+  "keywords": [
+    "geo",
+    "geospatial",
+    "geojson"
+  ],
+  "homepage": "https://github.com/jmikola/geojson",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Jeremy Mikola",
+      "email": "jmikola@gmail.com"
     }
+  ],
+  "require": {
+    "php": "^7.4 || ^8.0",
+    "ext-json": "*",
+    "symfony/polyfill-php80": "^1.25"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^9.5",
+    "scrutinizer/ocular": "^1.8.1",
+    "squizlabs/php_codesniffer": "^3.6",
+    "slevomat/coding-standard": "^7.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "GeoJson\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "GeoJson\\Tests\\": "tests/"
+    }
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-master": "1.1-dev"
+    }
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
+  }
 }

--- a/src/BoundingBox.php
+++ b/src/BoundingBox.php
@@ -66,6 +66,7 @@ class BoundingBox implements JsonSerializable, JsonUnserializable
         return $this->bounds;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize(): array
     {
         return $this->bounds;

--- a/src/CoordinateReferenceSystem/CoordinateReferenceSystem.php
+++ b/src/CoordinateReferenceSystem/CoordinateReferenceSystem.php
@@ -46,16 +46,17 @@ abstract class CoordinateReferenceSystem implements JsonSerializable, JsonUnseri
         return $this->type;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize(): array
     {
         return [
-            'type' => $this->type,
+            'type'       => $this->type,
             'properties' => $this->properties,
         ];
     }
 
     /**
-     * @param array|object $json
+     * @param  array|object  $json
      */
     final public static function jsonUnserialize($json): self
     {
@@ -92,7 +93,7 @@ abstract class CoordinateReferenceSystem implements JsonSerializable, JsonUnseri
      *
      * This method must be overridden in a child class.
      *
-     * @param array|object $properties
+     * @param  array|object  $properties
      *
      * @throws BadMethodCallException
      */

--- a/src/Exception/UnserializationException.php
+++ b/src/Exception/UnserializationException.php
@@ -17,7 +17,7 @@ class UnserializationException extends RuntimeException implements Exception
     /**
      * Creates an UnserializationException for a value with an invalid type.
      *
-     * @param mixed $value
+     * @param  mixed  $value
      */
     public static function invalidValue(string $context, $value, string $expectedType): self
     {
@@ -32,7 +32,7 @@ class UnserializationException extends RuntimeException implements Exception
     /**
      * Creates an UnserializationException for a property with an invalid type.
      *
-     * @param mixed $value
+     * @param  mixed  $value
      */
     public static function invalidProperty(string $context, string $property, $value, string $expectedType): self
     {

--- a/src/Feature/Feature.php
+++ b/src/Feature/Feature.php
@@ -39,8 +39,8 @@ class Feature extends GeoJson
     protected $id;
 
     /**
-     * @param int|string|null $id
-     * @param CoordinateReferenceSystem|BoundingBox $args
+     * @param  int|string|null  $id
+     * @param  CoordinateReferenceSystem|BoundingBox  $args
      */
     public function __construct(?Geometry $geometry = null, ?array $properties = null, $id = null, ...$args)
     {
@@ -77,6 +77,7 @@ class Feature extends GeoJson
         return $this->properties;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize(): array
     {
         $json = parent::jsonSerialize();

--- a/src/Feature/FeatureCollection.php
+++ b/src/Feature/FeatureCollection.php
@@ -70,6 +70,7 @@ class FeatureCollection extends GeoJson implements Countable, IteratorAggregate
         return new ArrayIterator($this->features);
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize(): array
     {
         return array_merge(

--- a/src/GeoJson.php
+++ b/src/GeoJson.php
@@ -53,6 +53,7 @@ abstract class GeoJson implements JsonSerializable, JsonUnserializable
         return $this->type;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize(): array
     {
         $json = ['type' => $this->type];
@@ -69,7 +70,7 @@ abstract class GeoJson implements JsonSerializable, JsonUnserializable
     }
 
     /**
-     * @param array|object $json
+     * @param  array|object  $json
      */
     final public static function jsonUnserialize($json): self
     {

--- a/src/Geometry/Geometry.php
+++ b/src/Geometry/Geometry.php
@@ -24,6 +24,7 @@ abstract class Geometry extends GeoJson
         return $this->coordinates;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize(): array
     {
         $json = parent::jsonSerialize();

--- a/src/Geometry/GeometryCollection.php
+++ b/src/Geometry/GeometryCollection.php
@@ -69,6 +69,7 @@ class GeometryCollection extends Geometry implements Countable, IteratorAggregat
         return new ArrayIterator($this->geometries);
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize(): array
     {
         return array_merge(


### PR DESCRIPTION
added `#[\ReturnTypeWillChange]` attributes to `jsonSerialize()`-methods to avoid php8.1 deprecation notes.

phpCS/Beautifier fails because of not imported ReturnTypeWillChange class, but it is only available with php8.1.
